### PR TITLE
Debug mode일 때 Debugging용 Admob Key를 매핑하게 변경

### DIFF
--- a/app/src/debug/res/values/keys.xml
+++ b/app/src/debug/res/values/keys.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="admobBannerId">ca-app-pub-3940256099942544/6300978111</string>
+    <string name="admobInterstitialId">ca-app-pub-3940256099942544/1033173712</string>
+</resources>

--- a/app/src/main/java/com/udtt/applegamsung/ui/applebox/AppleBoxActivity.kt
+++ b/app/src/main/java/com/udtt/applegamsung/ui/applebox/AppleBoxActivity.kt
@@ -71,6 +71,7 @@ class AppleBoxActivity : BaseActivity(), AppleBoxItemClickListener {
             override fun onAdLoaded(loadedInterstitialAd: InterstitialAd) {
                 super.onAdLoaded(loadedInterstitialAd)
 
+                interstitialAd = loadedInterstitialAd
                 loadedInterstitialAd.fullScreenContentCallback = object : FullScreenContentCallback() {
                     override fun onAdDismissedFullScreenContent() {
                         super.onAdDismissedFullScreenContent()


### PR DESCRIPTION
src 패키지 밑에 debug 패키지를 새로 둠.
gradle이 알아서 debug 패키지의 resource xml을 매핑해서 가져오게끔 구성함.

resolves #2 

---

추가적으로, InterstitialAd를 로드한 뒤 interstitialAd 변수를 초기화해주지 않아서, 전면 광고를 띄울 때 크래시 나던 현상도 해결함

resolves #1 
