### PR TITLE
Room 및 LocalDataSource의 구현을 Coroutines로 Migration

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -64,6 +64,7 @@ dependencies {
 
     // Room Database
     implementation "androidx.room:room-runtime:2.5.2"
+    implementation "androidx.room:room-ktx:2.5.2"
     kapt "androidx.room:room-compiler:2.5.2"
 
     // Koin Dependency Injection
@@ -79,6 +80,9 @@ dependencies {
 
     // AdMob
     implementation 'com.google.android.gms:play-services-ads:22.1.0'
+
+    // Coroutines
+    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.4'
 
     // Unit Test
     testImplementation 'junit:junit:4.13.2'

--- a/app/src/main/java/com/udtt/applegamsung/config/di/DatabaseModule.kt
+++ b/app/src/main/java/com/udtt/applegamsung/config/di/DatabaseModule.kt
@@ -3,14 +3,20 @@ package com.udtt.applegamsung.config.di
 import androidx.room.Room
 import com.google.firebase.firestore.FirebaseFirestore
 import com.udtt.applegamsung.data.AppDatabase
-import com.udtt.applegamsung.data.repository.*
+import com.udtt.applegamsung.data.repository.AppleBoxItemsRepository
+import com.udtt.applegamsung.data.repository.CategoriesRepository
+import com.udtt.applegamsung.data.repository.ProductsRepository
+import com.udtt.applegamsung.data.repository.TestResultsRepository
+import com.udtt.applegamsung.data.repository.UserIdentifyRepository
+import com.udtt.applegamsung.data.source.local.AppleBoxItemsLocalDataSource
 import com.udtt.applegamsung.data.source.local.CategoriesLocalDataSource
 import com.udtt.applegamsung.data.source.local.ProductsLocalDataSource
-import com.udtt.applegamsung.data.source.local.AppleBoxItemsLocalDataSource
 import com.udtt.applegamsung.data.source.local.TestResultsLocalDataSource
 import com.udtt.applegamsung.data.source.remote.CategoriesRemoteDataSource
 import com.udtt.applegamsung.data.source.remote.ProductsRemoteDataSource
 import com.udtt.applegamsung.data.source.remote.TestResultsRemoteDataSource
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 import org.koin.android.ext.koin.androidContext
 import org.koin.dsl.module
 
@@ -19,6 +25,10 @@ import org.koin.dsl.module
  * on 3월 15, 2020
  */
 
+val MainCoroutineScope = CoroutineScope(Dispatchers.Main)
+
+val IoCoroutineScope = CoroutineScope(Dispatchers.IO)
+
 val appDataBaseModule = module {
     single {
         Room.databaseBuilder(androidContext(), AppDatabase::class.java, "database").build()
@@ -26,10 +36,38 @@ val appDataBaseModule = module {
 }
 
 val localDataSourceModule = module {
-    single { CategoriesLocalDataSource(get(), get<AppDatabase>().categoriesDao()) }
-    single { ProductsLocalDataSource(get(), get<AppDatabase>().productsDao()) }
-    single { TestResultsLocalDataSource(get(), get<AppDatabase>().testResultsDao()) }
-    single { AppleBoxItemsLocalDataSource(get(), get<AppDatabase>().appleBoxItemsDao()) }
+    single {
+        CategoriesLocalDataSource(
+            get(),
+            get<AppDatabase>().categoriesDao(),
+            MainCoroutineScope,
+            IoCoroutineScope,
+        )
+    }
+    single {
+        ProductsLocalDataSource(
+            get(),
+            get<AppDatabase>().productsDao(),
+            MainCoroutineScope,
+            IoCoroutineScope,
+        )
+    }
+    single {
+        TestResultsLocalDataSource(
+            get(),
+            get<AppDatabase>().testResultsDao(),
+            MainCoroutineScope,
+            IoCoroutineScope,
+        )
+    }
+    single {
+        AppleBoxItemsLocalDataSource(
+            get(),
+            get<AppDatabase>().appleBoxItemsDao(),
+            MainCoroutineScope,
+            IoCoroutineScope,
+        )
+    }
 }
 
 val firestoreModule = module {
@@ -69,4 +107,3 @@ val repositoryModule = module {
         )
     }
 }
-

--- a/app/src/main/java/com/udtt/applegamsung/data/dao/AppleBoxItemsDao.kt
+++ b/app/src/main/java/com/udtt/applegamsung/data/dao/AppleBoxItemsDao.kt
@@ -10,18 +10,17 @@ import com.udtt.applegamsung.data.entity.AppleBoxItem
 interface AppleBoxItemsDao {
 
     @Query("SELECT * FROM appleboxitem ORDER BY categoryIndex, name")
-    fun getAppleBoxItems(): List<AppleBoxItem>
+    suspend fun getAppleBoxItems(): List<AppleBoxItem>
 
     @Insert
-    fun insertAppleBoxItems(appleBoxItems: List<AppleBoxItem>)
+    suspend fun insertAppleBoxItems(appleBoxItems: List<AppleBoxItem>)
 
     @Delete
-    fun deleteAppleBoxItem(appleBoxItem: AppleBoxItem)
+    suspend fun deleteAppleBoxItem(appleBoxItem: AppleBoxItem)
 
     @Delete
-    fun deleteAppleBoxItems(appleBoxItems: List<AppleBoxItem>)
+    suspend fun deleteAppleBoxItems(appleBoxItems: List<AppleBoxItem>)
 
     @Query("DELETE FROM appleboxitem")
-    fun deleteAllAppleBoxItems()
-
+    suspend fun deleteAllAppleBoxItems()
 }

--- a/app/src/main/java/com/udtt/applegamsung/data/dao/CategoriesDao.kt
+++ b/app/src/main/java/com/udtt/applegamsung/data/dao/CategoriesDao.kt
@@ -15,9 +15,8 @@ import com.udtt.applegamsung.data.entity.Category
 interface CategoriesDao {
 
     @Query("SELECT * FROM category")
-    fun getCategories(): List<Category>
+    suspend fun getCategories(): List<Category>
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
-    fun insertCategories(categories: List<Category>)
-
+    suspend fun insertCategories(categories: List<Category>)
 }

--- a/app/src/main/java/com/udtt/applegamsung/data/dao/ProductsDao.kt
+++ b/app/src/main/java/com/udtt/applegamsung/data/dao/ProductsDao.kt
@@ -14,9 +14,8 @@ import com.udtt.applegamsung.data.entity.Product
 interface ProductsDao {
 
     @Query("SELECT * FROM product WHERE categoryId = :categoryId ORDER BY name")
-    fun getProductsByCategoryId(categoryId: String): List<Product>
+    suspend fun getProductsByCategoryId(categoryId: String): List<Product>
 
     @Insert
-    fun insertProducts(products: List<Product>)
-
+    suspend fun insertProducts(products: List<Product>)
 }

--- a/app/src/main/java/com/udtt/applegamsung/data/dao/TestResultsDao.kt
+++ b/app/src/main/java/com/udtt/applegamsung/data/dao/TestResultsDao.kt
@@ -15,21 +15,20 @@ import com.udtt.applegamsung.data.entity.TestResult
 interface TestResultsDao {
 
     @Query("SELECT * FROM testresult")
-    fun getTestResults(): List<TestResult>
+    suspend fun getTestResults(): List<TestResult>
 
     @Insert
-    fun insertTestResult(testResult: TestResult)
+    suspend fun insertTestResult(testResult: TestResult)
 
     @Query("DELETE FROM testresult")
-    fun deleteAllTestResults()
+    suspend fun deleteAllTestResults()
 
     @Query("SELECT * FROM applepower")
-    fun getApplePowers(): List<ApplePower>
+    suspend fun getApplePowers(): List<ApplePower>
 
     @Query("SELECT * FROM applepower WHERE maxPower >= :totalScore AND minPower <= :totalScore ORDER BY maxPower LIMIT(1)")
-    fun getApplePower(totalScore: Int): ApplePower?
+    suspend fun getApplePower(totalScore: Int): ApplePower?
 
     @Insert
-    fun insertApplePower(applePowers: List<ApplePower>)
-
+    suspend fun insertApplePower(applePowers: List<ApplePower>)
 }

--- a/app/src/main/java/com/udtt/applegamsung/data/source/local/AppleBoxItemsLocalDataSource.kt
+++ b/app/src/main/java/com/udtt/applegamsung/data/source/local/AppleBoxItemsLocalDataSource.kt
@@ -3,43 +3,42 @@ package com.udtt.applegamsung.data.source.local
 import com.udtt.applegamsung.data.dao.AppleBoxItemsDao
 import com.udtt.applegamsung.data.entity.AppleBoxItem
 import com.udtt.applegamsung.data.source.AppleBoxItemsDataSource
-import com.udtt.applegamsung.util.AsyncExecutor
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
 
 class AppleBoxItemsLocalDataSource(
-    private val asyncExecutor: AsyncExecutor,
     private val appleBoxItemsDao: AppleBoxItemsDao,
     private val mainCoroutineScope: CoroutineScope,
     private val ioCoroutineScope: CoroutineScope,
 ) : AppleBoxItemsDataSource {
 
     override fun getAppleBoxItems(callback: (appleBoxItems: List<AppleBoxItem>) -> Unit) {
-        asyncExecutor.ioThread.execute {
+        ioCoroutineScope.launch {
             val appleBoxItems = appleBoxItemsDao.getAppleBoxItems()
-            asyncExecutor.mainThread.execute { callback(appleBoxItems) }
+            mainCoroutineScope.launch { callback(appleBoxItems) }
         }
     }
 
     override fun saveAppleBoxItems(appleBoxItems: List<AppleBoxItem>) {
-        asyncExecutor.ioThread.execute {
+        ioCoroutineScope.launch {
             appleBoxItemsDao.insertAppleBoxItems(appleBoxItems)
         }
     }
 
     override fun removeAppleBoxItem(itemToRemove: AppleBoxItem) {
-        asyncExecutor.ioThread.execute {
+        ioCoroutineScope.launch {
             appleBoxItemsDao.deleteAppleBoxItem(itemToRemove)
         }
     }
 
     override fun removeAppleBoxItems(itemsToRemove: List<AppleBoxItem>) {
-        asyncExecutor.ioThread.execute {
+        ioCoroutineScope.launch {
             appleBoxItemsDao.deleteAppleBoxItems(itemsToRemove)
         }
     }
 
     override fun removeAllAppleBoxItems() {
-        asyncExecutor.ioThread.execute {
+        ioCoroutineScope.launch {
             appleBoxItemsDao.deleteAllAppleBoxItems()
         }
     }

--- a/app/src/main/java/com/udtt/applegamsung/data/source/local/AppleBoxItemsLocalDataSource.kt
+++ b/app/src/main/java/com/udtt/applegamsung/data/source/local/AppleBoxItemsLocalDataSource.kt
@@ -4,10 +4,13 @@ import com.udtt.applegamsung.data.dao.AppleBoxItemsDao
 import com.udtt.applegamsung.data.entity.AppleBoxItem
 import com.udtt.applegamsung.data.source.AppleBoxItemsDataSource
 import com.udtt.applegamsung.util.AsyncExecutor
+import kotlinx.coroutines.CoroutineScope
 
 class AppleBoxItemsLocalDataSource(
     private val asyncExecutor: AsyncExecutor,
-    private val appleBoxItemsDao: AppleBoxItemsDao
+    private val appleBoxItemsDao: AppleBoxItemsDao,
+    private val mainCoroutineScope: CoroutineScope,
+    private val ioCoroutineScope: CoroutineScope,
 ) : AppleBoxItemsDataSource {
 
     override fun getAppleBoxItems(callback: (appleBoxItems: List<AppleBoxItem>) -> Unit) {

--- a/app/src/main/java/com/udtt/applegamsung/data/source/local/CategoriesLocalDataSource.kt
+++ b/app/src/main/java/com/udtt/applegamsung/data/source/local/CategoriesLocalDataSource.kt
@@ -4,6 +4,7 @@ import com.udtt.applegamsung.data.dao.CategoriesDao
 import com.udtt.applegamsung.data.entity.Category
 import com.udtt.applegamsung.data.source.CategoriesDataSource
 import com.udtt.applegamsung.util.AsyncExecutor
+import kotlinx.coroutines.CoroutineScope
 
 /**
  * Created By Yun Hyeok
@@ -12,7 +13,9 @@ import com.udtt.applegamsung.util.AsyncExecutor
 
 class CategoriesLocalDataSource(
     private val asyncExecutor: AsyncExecutor,
-    private val categoriesDao: CategoriesDao
+    private val categoriesDao: CategoriesDao,
+    private val mainCoroutineScope: CoroutineScope,
+    private val ioCoroutineScope: CoroutineScope,
 ) : CategoriesDataSource {
 
     override fun getCategories(callback: (categories: List<Category>) -> Unit) {

--- a/app/src/main/java/com/udtt/applegamsung/data/source/local/CategoriesLocalDataSource.kt
+++ b/app/src/main/java/com/udtt/applegamsung/data/source/local/CategoriesLocalDataSource.kt
@@ -3,8 +3,8 @@ package com.udtt.applegamsung.data.source.local
 import com.udtt.applegamsung.data.dao.CategoriesDao
 import com.udtt.applegamsung.data.entity.Category
 import com.udtt.applegamsung.data.source.CategoriesDataSource
-import com.udtt.applegamsung.util.AsyncExecutor
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
 
 /**
  * Created By Yun Hyeok
@@ -12,21 +12,20 @@ import kotlinx.coroutines.CoroutineScope
  */
 
 class CategoriesLocalDataSource(
-    private val asyncExecutor: AsyncExecutor,
     private val categoriesDao: CategoriesDao,
     private val mainCoroutineScope: CoroutineScope,
     private val ioCoroutineScope: CoroutineScope,
 ) : CategoriesDataSource {
 
     override fun getCategories(callback: (categories: List<Category>) -> Unit) {
-        asyncExecutor.ioThread.execute {
+        ioCoroutineScope.launch {
             val categories = categoriesDao.getCategories()
-            asyncExecutor.mainThread.execute { callback(categories) }
+            mainCoroutineScope.launch { callback(categories) }
         }
     }
 
     override fun saveCategories(categories: List<Category>) {
-        asyncExecutor.ioThread.execute {
+        ioCoroutineScope.launch {
             categoriesDao.insertCategories(categories)
         }
     }

--- a/app/src/main/java/com/udtt/applegamsung/data/source/local/ProductsLocalDataSource.kt
+++ b/app/src/main/java/com/udtt/applegamsung/data/source/local/ProductsLocalDataSource.kt
@@ -3,8 +3,8 @@ package com.udtt.applegamsung.data.source.local
 import com.udtt.applegamsung.data.dao.ProductsDao
 import com.udtt.applegamsung.data.entity.Product
 import com.udtt.applegamsung.data.source.ProductsDataSource
-import com.udtt.applegamsung.util.AsyncExecutor
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
 
 /**
  * Created By Yun Hyeok
@@ -12,21 +12,20 @@ import kotlinx.coroutines.CoroutineScope
  */
 
 class ProductsLocalDataSource(
-    private val asyncExecutor: AsyncExecutor,
     private val productsDao: ProductsDao,
     private val mainCoroutineScope: CoroutineScope,
     private val ioCoroutineScope: CoroutineScope,
 ) : ProductsDataSource {
 
     override fun getProducts(categoryId: String, callback: (products: List<Product>) -> Unit) {
-        asyncExecutor.ioThread.execute {
+        ioCoroutineScope.launch {
             val products = productsDao.getProductsByCategoryId(categoryId)
-            asyncExecutor.mainThread.execute { callback(products) }
+            mainCoroutineScope.launch { callback(products) }
         }
     }
 
     override fun saveProducts(products: List<Product>) {
-        asyncExecutor.ioThread.execute {
+        ioCoroutineScope.launch {
             productsDao.insertProducts(products)
         }
     }

--- a/app/src/main/java/com/udtt/applegamsung/data/source/local/ProductsLocalDataSource.kt
+++ b/app/src/main/java/com/udtt/applegamsung/data/source/local/ProductsLocalDataSource.kt
@@ -4,6 +4,7 @@ import com.udtt.applegamsung.data.dao.ProductsDao
 import com.udtt.applegamsung.data.entity.Product
 import com.udtt.applegamsung.data.source.ProductsDataSource
 import com.udtt.applegamsung.util.AsyncExecutor
+import kotlinx.coroutines.CoroutineScope
 
 /**
  * Created By Yun Hyeok
@@ -12,7 +13,9 @@ import com.udtt.applegamsung.util.AsyncExecutor
 
 class ProductsLocalDataSource(
     private val asyncExecutor: AsyncExecutor,
-    private val productsDao: ProductsDao
+    private val productsDao: ProductsDao,
+    private val mainCoroutineScope: CoroutineScope,
+    private val ioCoroutineScope: CoroutineScope,
 ) : ProductsDataSource {
 
     override fun getProducts(categoryId: String, callback: (products: List<Product>) -> Unit) {

--- a/app/src/main/java/com/udtt/applegamsung/data/source/local/TestResultsLocalDataSource.kt
+++ b/app/src/main/java/com/udtt/applegamsung/data/source/local/TestResultsLocalDataSource.kt
@@ -4,8 +4,8 @@ import com.udtt.applegamsung.data.dao.TestResultsDao
 import com.udtt.applegamsung.data.entity.ApplePower
 import com.udtt.applegamsung.data.entity.TestResult
 import com.udtt.applegamsung.data.source.TestResultsDataSource
-import com.udtt.applegamsung.util.AsyncExecutor
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
 
 /**
  * Created By Yun Hyeok
@@ -13,47 +13,46 @@ import kotlinx.coroutines.CoroutineScope
  */
 
 class TestResultsLocalDataSource(
-    private val asyncExecutor: AsyncExecutor,
     private val testResultsDao: TestResultsDao,
     private val mainCoroutineScope: CoroutineScope,
     private val ioCoroutineScope: CoroutineScope,
 ) : TestResultsDataSource {
 
     override fun getTestResults(callback: (testResults: List<TestResult>) -> Unit) {
-        asyncExecutor.ioThread.execute {
+        ioCoroutineScope.launch {
             val testResults = testResultsDao.getTestResults()
-            asyncExecutor.mainThread.execute { callback(testResults) }
+            mainCoroutineScope.launch { callback(testResults) }
         }
     }
 
     override fun saveTestResult(testResult: TestResult) {
-        asyncExecutor.ioThread.execute {
+        ioCoroutineScope.launch {
             testResultsDao.insertTestResult(testResult)
         }
     }
 
     override fun getApplePowers(callback: (applePowers: List<ApplePower>) -> Unit) {
-        asyncExecutor.ioThread.execute {
+        ioCoroutineScope.launch {
             val applePowers = testResultsDao.getApplePowers()
-            asyncExecutor.mainThread.execute { callback(applePowers) }
+            mainCoroutineScope.launch { callback(applePowers) }
         }
     }
 
     override fun getApplePower(totalScore: Int, callback: (applePower: ApplePower?) -> Unit) {
-        asyncExecutor.ioThread.execute {
+        ioCoroutineScope.launch {
             val applePower = testResultsDao.getApplePower(totalScore)
-            asyncExecutor.mainThread.execute { callback(applePower) }
+            mainCoroutineScope.launch { callback(applePower) }
         }
     }
 
     override fun saveApplePowers(applePowers: List<ApplePower>) {
-        asyncExecutor.ioThread.execute {
+        ioCoroutineScope.launch {
             testResultsDao.insertApplePower(applePowers)
         }
     }
 
     override fun removeAllTestResults() {
-        asyncExecutor.ioThread.execute {
+        ioCoroutineScope.launch {
             testResultsDao.deleteAllTestResults()
         }
     }

--- a/app/src/main/java/com/udtt/applegamsung/data/source/local/TestResultsLocalDataSource.kt
+++ b/app/src/main/java/com/udtt/applegamsung/data/source/local/TestResultsLocalDataSource.kt
@@ -5,6 +5,7 @@ import com.udtt.applegamsung.data.entity.ApplePower
 import com.udtt.applegamsung.data.entity.TestResult
 import com.udtt.applegamsung.data.source.TestResultsDataSource
 import com.udtt.applegamsung.util.AsyncExecutor
+import kotlinx.coroutines.CoroutineScope
 
 /**
  * Created By Yun Hyeok
@@ -13,7 +14,9 @@ import com.udtt.applegamsung.util.AsyncExecutor
 
 class TestResultsLocalDataSource(
     private val asyncExecutor: AsyncExecutor,
-    private val testResultsDao: TestResultsDao
+    private val testResultsDao: TestResultsDao,
+    private val mainCoroutineScope: CoroutineScope,
+    private val ioCoroutineScope: CoroutineScope,
 ) : TestResultsDataSource {
 
     override fun getTestResults(callback: (testResults: List<TestResult>) -> Unit) {


### PR DESCRIPTION
Executor로 구현되어있던 LocalSource와 Room을 모두 Coroutines로 Migaration하는 작업을 진행함.
CoroutineScope를 주입하는 과정은 대충 변경함.
추후 다듬어야함.