### PR TITLE
Koin LocalSource 생성 잘못 작성한 것과 Room Scheme Export하게 변경

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -39,6 +39,12 @@ android {
     }
     namespace 'com.udtt.applegamsung'
 
+    kapt {
+        arguments {
+            arg("room.schemaLocation", "$projectDir/schemas")
+        }
+    }
+
     compileOptions {
         sourceCompatibility = 17
         targetCompatibility = 17

--- a/app/schemas/com.udtt.applegamsung.data.AppDatabase/1.json
+++ b/app/schemas/com.udtt.applegamsung.data.AppDatabase/1.json
@@ -1,0 +1,258 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 1,
+    "identityHash": "b782b07768402004f16d743a7ddb33d2",
+    "entities": [
+      {
+        "tableName": "Category",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`name` TEXT NOT NULL, `index` INTEGER NOT NULL, `id` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "index",
+            "columnName": "index",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "Product",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`name` TEXT NOT NULL, `score` INTEGER NOT NULL, `categoryIndex` INTEGER NOT NULL, `categoryId` TEXT NOT NULL, `imageUrl` TEXT NOT NULL, `id` TEXT NOT NULL, `imageByteArray` BLOB, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "score",
+            "columnName": "score",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "categoryIndex",
+            "columnName": "categoryIndex",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "categoryId",
+            "columnName": "categoryId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "imageUrl",
+            "columnName": "imageUrl",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "imageByteArray",
+            "columnName": "imageByteArray",
+            "affinity": "BLOB",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "TestResult",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`deviceId` TEXT NOT NULL, `nickname` TEXT NOT NULL, `totalScore` INTEGER NOT NULL, `timeStamp` INTEGER NOT NULL, `id` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "deviceId",
+            "columnName": "deviceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "nickname",
+            "columnName": "nickname",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "totalScore",
+            "columnName": "totalScore",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timeStamp",
+            "columnName": "timeStamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "AppleBoxItem",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`hasAppleCare` INTEGER NOT NULL, `apple_box_id` TEXT NOT NULL, `name` TEXT NOT NULL, `score` INTEGER NOT NULL, `categoryIndex` INTEGER NOT NULL, `categoryId` TEXT NOT NULL, `imageUrl` TEXT NOT NULL, `id` TEXT NOT NULL, `imageByteArray` BLOB, PRIMARY KEY(`apple_box_id`))",
+        "fields": [
+          {
+            "fieldPath": "hasAppleCare",
+            "columnName": "hasAppleCare",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "apple_box_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "product.name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "product.score",
+            "columnName": "score",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "product.categoryIndex",
+            "columnName": "categoryIndex",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "product.categoryId",
+            "columnName": "categoryId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "product.imageUrl",
+            "columnName": "imageUrl",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "product.id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "product.imageByteArray",
+            "columnName": "imageByteArray",
+            "affinity": "BLOB",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "apple_box_id"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "ApplePower",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`name` TEXT NOT NULL, `description` TEXT NOT NULL, `minPower` INTEGER NOT NULL, `maxPower` INTEGER NOT NULL, `id` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "minPower",
+            "columnName": "minPower",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "maxPower",
+            "columnName": "maxPower",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      }
+    ],
+    "views": [],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'b782b07768402004f16d743a7ddb33d2')"
+    ]
+  }
+}

--- a/app/src/main/java/com/udtt/applegamsung/config/di/DatabaseModule.kt
+++ b/app/src/main/java/com/udtt/applegamsung/config/di/DatabaseModule.kt
@@ -38,7 +38,6 @@ val appDataBaseModule = module {
 val localDataSourceModule = module {
     single {
         CategoriesLocalDataSource(
-            get(),
             get<AppDatabase>().categoriesDao(),
             MainCoroutineScope,
             IoCoroutineScope,
@@ -46,7 +45,6 @@ val localDataSourceModule = module {
     }
     single {
         ProductsLocalDataSource(
-            get(),
             get<AppDatabase>().productsDao(),
             MainCoroutineScope,
             IoCoroutineScope,
@@ -54,7 +52,6 @@ val localDataSourceModule = module {
     }
     single {
         TestResultsLocalDataSource(
-            get(),
             get<AppDatabase>().testResultsDao(),
             MainCoroutineScope,
             IoCoroutineScope,
@@ -62,7 +59,6 @@ val localDataSourceModule = module {
     }
     single {
         AppleBoxItemsLocalDataSource(
-            get(),
             get<AppDatabase>().appleBoxItemsDao(),
             MainCoroutineScope,
             IoCoroutineScope,


### PR DESCRIPTION
#5 에서 LocalDataSource의 생성자 파라미터를 변경해놓고, Koin에서 생성하는 로직을 그대로 냅둬버림..
그래서 컴파일 에러가 발생했었음.
해당 에러를 해결함

Room Database의 Schema 파일을 생성하지 않고 있었음.
해당 파일은 Room AutoMigration을 활용할 때 매우 중요하기도 하고,
Database의 Schema History를 파악하기 위한 수단이므로 저장하게 변경했음.

이후 모듈을 나눌 때 LocalSource 모듈에 해당 Scheme을 뱉어내게 수정해야하는데,
아마 build gradle 옮기면서 같이 옮겨질 것으로 예상됨.