### PR TITLE
Firestore 및 RemoteSource의 구현을 Coroutines로 migration

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -58,6 +58,7 @@ android {
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
+    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-play-services:1.6.4"
     implementation 'androidx.appcompat:appcompat:1.6.1'
     implementation 'androidx.core:core-ktx:1.10.1'
     implementation 'androidx.constraintlayout:constraintlayout:2.1.4'

--- a/app/src/main/java/com/udtt/applegamsung/data/remote/firestore/FirestoreExt.kt
+++ b/app/src/main/java/com/udtt/applegamsung/data/remote/firestore/FirestoreExt.kt
@@ -1,14 +1,7 @@
 package com.udtt.applegamsung.data.remote.firestore
 
-import com.google.android.gms.tasks.Task
 import com.google.firebase.firestore.CollectionReference
-import com.google.firebase.firestore.DocumentReference
 import com.google.firebase.firestore.DocumentSnapshot
-import com.google.firebase.firestore.FirebaseFirestore
-import com.google.firebase.firestore.QuerySnapshot
-import com.udtt.applegamsung.data.entity.ApplePower
-import com.udtt.applegamsung.data.entity.Category
-import com.udtt.applegamsung.data.entity.Product
 import kotlinx.coroutines.tasks.await
 
 /**
@@ -19,43 +12,3 @@ import kotlinx.coroutines.tasks.await
 suspend fun CollectionReference.getDocumentSnapshots(): List<DocumentSnapshot> {
     return this.get().await().documents
 }
-
-fun DocumentReference.getCollection(collectionPath: String): Task<QuerySnapshot> {
-    return this.collection(collectionPath).get()
-}
-
-fun FirebaseFirestore.getCollection(collectionPath: String): Task<QuerySnapshot> {
-    return this.collection(collectionPath).get()
-}
-
-fun FirebaseFirestore.getCategoryDocumentById(categoryId: String): DocumentReference {
-    return this.collection(CATEGORIES_PATH).document(categoryId)
-}
-
-fun QuerySnapshot.toCategories(): List<Category> {
-    return this.documents.map {
-        val category = it.toObject(Category::class.java) ?: throw CANNOT_CONVERT_EXCEPTION
-        category.apply { id = it.id }
-    }
-}
-
-fun QuerySnapshot.toProductsOf(categoryId: String): List<Product> {
-    return this.documents.map {
-        val product = it.toObject(Product::class.java) ?: throw CANNOT_CONVERT_EXCEPTION
-        product.apply { this.categoryId = categoryId }
-    }.sortedBy { it.name }
-}
-
-fun QuerySnapshot.toApplePowers(): List<ApplePower> {
-    return this.documents.map {
-        val applePower = it.toObject(ApplePower::class.java) ?: throw CANNOT_CONVERT_EXCEPTION
-        applePower.apply { this.id = it.id }
-    }.sortedBy { it.name }
-}
-
-const val CATEGORIES_PATH = "categories"
-const val PRODUCTS_PATH = "products"
-const val TEST_RESULTS_PATH = "testResults"
-const val APPLE_POWER_PATH = "ApplePower"
-
-private val CANNOT_CONVERT_EXCEPTION = IllegalStateException("객체를 변환할 수 없음")

--- a/app/src/main/java/com/udtt/applegamsung/data/remote/firestore/FirestoreExt.kt
+++ b/app/src/main/java/com/udtt/applegamsung/data/remote/firestore/FirestoreExt.kt
@@ -1,17 +1,24 @@
-package com.udtt.applegamsung.data.util
+package com.udtt.applegamsung.data.remote.firestore
 
 import com.google.android.gms.tasks.Task
+import com.google.firebase.firestore.CollectionReference
 import com.google.firebase.firestore.DocumentReference
+import com.google.firebase.firestore.DocumentSnapshot
 import com.google.firebase.firestore.FirebaseFirestore
 import com.google.firebase.firestore.QuerySnapshot
 import com.udtt.applegamsung.data.entity.ApplePower
 import com.udtt.applegamsung.data.entity.Category
 import com.udtt.applegamsung.data.entity.Product
+import kotlinx.coroutines.tasks.await
 
 /**
  * Created By Yun Hyeok
  * on 3월 15, 2020
  */
+
+suspend fun CollectionReference.getDocumentSnapshots(): List<DocumentSnapshot> {
+    return this.get().await().documents
+}
 
 fun DocumentReference.getCollection(collectionPath: String): Task<QuerySnapshot> {
     return this.collection(collectionPath).get()

--- a/app/src/main/java/com/udtt/applegamsung/data/source/remote/CategoriesRemoteDataSource.kt
+++ b/app/src/main/java/com/udtt/applegamsung/data/source/remote/CategoriesRemoteDataSource.kt
@@ -2,16 +2,11 @@ package com.udtt.applegamsung.data.source.remote
 
 import com.google.firebase.firestore.FirebaseFirestore
 import com.udtt.applegamsung.data.entity.Category
+import com.udtt.applegamsung.data.remote.firestore.getDocumentSnapshots
 import com.udtt.applegamsung.data.source.CategoriesDataSource
-import com.udtt.applegamsung.data.remote.firestore.CATEGORIES_PATH
-import com.udtt.applegamsung.data.remote.firestore.getCollection
-import com.udtt.applegamsung.data.remote.firestore.toCategories
-import com.udtt.applegamsung.util.log
-import com.udtt.applegamsung.util.showStackTrace
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.tasks.await
 
 /**
  * Created By Yun Hyeok
@@ -19,20 +14,29 @@ import kotlinx.coroutines.tasks.await
  */
 
 class CategoriesRemoteDataSource(
-    private val fireStore: FirebaseFirestore
+    private val firestore: FirebaseFirestore
 ) : CategoriesDataSource {
 
     override fun getCategories(callback: (categories: List<Category>) -> Unit) {
-        CoroutineScope(Dispatchers.IO).launch {
-            fireStore.getCollection(CATEGORIES_PATH).await().toCategories()
+        CoroutineScope(Dispatchers.Main).launch {
+            val categories = firestore.collection(PathCategory)
+                .getDocumentSnapshots()
+                .map {
+                    Category(
+                        id = it.id,
+                        name = it.getString("name").orEmpty(),
+                        index = it.getLong("index")?.toInt() ?: 0,
+                    )
+                }
+            callback(categories)
         }
-
-        fireStore.getCollection(CATEGORIES_PATH)
-            .addOnSuccessListener { callback(it.toCategories()) }
-            .addOnFailureListener { log(it.showStackTrace()) }
     }
 
     override fun saveCategories(categories: List<Category>) {
-        // No Needed
+        throw UnsupportedOperationException("Do not call saveCategories() in remoteSource")
+    }
+
+    companion object {
+        private const val PathCategory = "categories"
     }
 }

--- a/app/src/main/java/com/udtt/applegamsung/data/source/remote/CategoriesRemoteDataSource.kt
+++ b/app/src/main/java/com/udtt/applegamsung/data/source/remote/CategoriesRemoteDataSource.kt
@@ -3,11 +3,15 @@ package com.udtt.applegamsung.data.source.remote
 import com.google.firebase.firestore.FirebaseFirestore
 import com.udtt.applegamsung.data.entity.Category
 import com.udtt.applegamsung.data.source.CategoriesDataSource
-import com.udtt.applegamsung.data.util.CATEGORIES_PATH
-import com.udtt.applegamsung.data.util.getCollection
-import com.udtt.applegamsung.data.util.toCategories
+import com.udtt.applegamsung.data.remote.firestore.CATEGORIES_PATH
+import com.udtt.applegamsung.data.remote.firestore.getCollection
+import com.udtt.applegamsung.data.remote.firestore.toCategories
 import com.udtt.applegamsung.util.log
 import com.udtt.applegamsung.util.showStackTrace
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.tasks.await
 
 /**
  * Created By Yun Hyeok
@@ -19,6 +23,10 @@ class CategoriesRemoteDataSource(
 ) : CategoriesDataSource {
 
     override fun getCategories(callback: (categories: List<Category>) -> Unit) {
+        CoroutineScope(Dispatchers.IO).launch {
+            fireStore.getCollection(CATEGORIES_PATH).await().toCategories()
+        }
+
         fireStore.getCollection(CATEGORIES_PATH)
             .addOnSuccessListener { callback(it.toCategories()) }
             .addOnFailureListener { log(it.showStackTrace()) }

--- a/app/src/main/java/com/udtt/applegamsung/data/source/remote/ProductsRemoteDataSource.kt
+++ b/app/src/main/java/com/udtt/applegamsung/data/source/remote/ProductsRemoteDataSource.kt
@@ -2,11 +2,11 @@ package com.udtt.applegamsung.data.source.remote
 
 import com.google.firebase.firestore.FirebaseFirestore
 import com.udtt.applegamsung.data.entity.Product
+import com.udtt.applegamsung.data.remote.firestore.PRODUCTS_PATH
+import com.udtt.applegamsung.data.remote.firestore.getCategoryDocumentById
+import com.udtt.applegamsung.data.remote.firestore.getCollection
+import com.udtt.applegamsung.data.remote.firestore.toProductsOf
 import com.udtt.applegamsung.data.source.ProductsDataSource
-import com.udtt.applegamsung.data.util.PRODUCTS_PATH
-import com.udtt.applegamsung.data.util.getCategoryDocumentById
-import com.udtt.applegamsung.data.util.getCollection
-import com.udtt.applegamsung.data.util.toProductsOf
 import com.udtt.applegamsung.util.log
 import com.udtt.applegamsung.util.showStackTrace
 

--- a/app/src/main/java/com/udtt/applegamsung/data/source/remote/ProductsRemoteDataSource.kt
+++ b/app/src/main/java/com/udtt/applegamsung/data/source/remote/ProductsRemoteDataSource.kt
@@ -2,13 +2,11 @@ package com.udtt.applegamsung.data.source.remote
 
 import com.google.firebase.firestore.FirebaseFirestore
 import com.udtt.applegamsung.data.entity.Product
-import com.udtt.applegamsung.data.remote.firestore.PRODUCTS_PATH
-import com.udtt.applegamsung.data.remote.firestore.getCategoryDocumentById
-import com.udtt.applegamsung.data.remote.firestore.getCollection
-import com.udtt.applegamsung.data.remote.firestore.toProductsOf
+import com.udtt.applegamsung.data.remote.firestore.getDocumentSnapshots
 import com.udtt.applegamsung.data.source.ProductsDataSource
-import com.udtt.applegamsung.util.log
-import com.udtt.applegamsung.util.showStackTrace
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
 
 /**
  * Created By Yun Hyeok
@@ -20,13 +18,30 @@ class ProductsRemoteDataSource(
 ) : ProductsDataSource {
 
     override fun getProducts(categoryId: String, callback: (products: List<Product>) -> Unit) {
-        firestore.getCategoryDocumentById(categoryId)
-            .getCollection(PRODUCTS_PATH)
-            .addOnSuccessListener { callback(it.toProductsOf(categoryId)) }
-            .addOnFailureListener { log(it.showStackTrace()) }
+        CoroutineScope(Dispatchers.Main).launch {
+            val products = firestore.collection(PathCategory)
+                .document(categoryId)
+                .collection(PathProducts)
+                .getDocumentSnapshots()
+                .map {
+                    Product(
+                        id = it.id,
+                        name = it.getString("name").orEmpty(),
+                        score = it.getLong("score")?.toInt() ?: 0,
+                        categoryIndex = it.getLong("categoryIndex")?.toInt() ?: 0,
+                        categoryId = it.getString("categoryId").orEmpty(),
+                    )
+                }
+            callback(products)
+        }
     }
 
     override fun saveProducts(products: List<Product>) {
-        // No Needed
+        throw UnsupportedOperationException("Do not call saveProducts() in remoteSource")
+    }
+
+    companion object {
+        private const val PathCategory = "categories"
+        private const val PathProducts = "products"
     }
 }

--- a/app/src/main/java/com/udtt/applegamsung/data/source/remote/TestResultsRemoteDataSource.kt
+++ b/app/src/main/java/com/udtt/applegamsung/data/source/remote/TestResultsRemoteDataSource.kt
@@ -4,10 +4,10 @@ import com.google.firebase.firestore.FirebaseFirestore
 import com.udtt.applegamsung.data.entity.ApplePower
 import com.udtt.applegamsung.data.entity.TestResult
 import com.udtt.applegamsung.data.source.TestResultsDataSource
-import com.udtt.applegamsung.data.util.APPLE_POWER_PATH
-import com.udtt.applegamsung.data.util.TEST_RESULTS_PATH
-import com.udtt.applegamsung.data.util.getCollection
-import com.udtt.applegamsung.data.util.toApplePowers
+import com.udtt.applegamsung.data.remote.firestore.APPLE_POWER_PATH
+import com.udtt.applegamsung.data.remote.firestore.TEST_RESULTS_PATH
+import com.udtt.applegamsung.data.remote.firestore.getCollection
+import com.udtt.applegamsung.data.remote.firestore.toApplePowers
 import com.udtt.applegamsung.util.log
 import com.udtt.applegamsung.util.showStackTrace
 


### PR DESCRIPTION
- close #8 

## Firestore 변경
1. Firestore의 Callback 방식 구현을 Coroutine를 활용하게 변경함.
2. 확장 함수로 활용하고 있던 특정 Collection 및 Document 접근을 RemoteSource의 관심사로 변경함
3. 확장 함수를 정리함.
    - 쓸데없는 형태의 확장함수 모두 제거함.
    - firestore의 collection(), document() 체이닝을 함으로써 데이터를 가져오는 특징을 최대한 살려 가독성을 높임.

### RemoteSource와 Firestore 사이 하나의 레이어를 둬야할 지 고민이었음.
현재는 중간 레이어를 두지 않음.
collection 경로 등 remoteSource에서 직접 갖고 있고, 중복되는 경우가 존재함.
Firestore의 응답 값의 필드 명을 직접 가지고 있거나, collection 경로를 직접 알고 있는 것 등은 RemoteSource가 가질 관심이 아닌 것으로 판단됨. 중간 레이어를 두는 것도 좋은 방법이라 생각됨.
- #15


## RemoteSource 변경
1. 임시로 CoroutineScope는 하드코딩으로 작성함. 이후 사라질 것임.
2. 사용하지 않는 메서드에는 UnSupportedOperationException을 발생시키도록 구현함.
    - 애초에 기능이 없으므로, 사용시 아무런 기능을 하기 보다 사용하지 못하도록 의도함.