### PR TITLE
Remote ApplePower를 불러오지 못하던 문제 해결

### DIFF
--- a/app/src/main/java/com/udtt/applegamsung/data/dao/ApplePowersDao.kt
+++ b/app/src/main/java/com/udtt/applegamsung/data/dao/ApplePowersDao.kt
@@ -2,6 +2,7 @@ package com.udtt.applegamsung.data.dao
 
 import androidx.room.Dao
 import androidx.room.Insert
+import androidx.room.OnConflictStrategy
 import androidx.room.Query
 import com.udtt.applegamsung.data.entity.ApplePowerEntity
 
@@ -11,6 +12,6 @@ interface ApplePowersDao {
     @Query("SELECT * FROM ApplePowerEntity")
     suspend fun getApplePowers(): List<ApplePowerEntity>
 
-    @Insert
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun insertApplePower(applePowers: List<ApplePowerEntity>)
 }

--- a/app/src/main/java/com/udtt/applegamsung/data/source/local/TestResultsLocalDataSource.kt
+++ b/app/src/main/java/com/udtt/applegamsung/data/source/local/TestResultsLocalDataSource.kt
@@ -49,8 +49,8 @@ class TestResultsLocalDataSource(
     override fun getApplePower(totalScore: Int, callback: (applePower: ApplePower?) -> Unit) {
         ioCoroutineScope.launch {
             val applePower = applePowersDao.getApplePowers()
-                .first { totalScore in it.minScore..it.maxScore }
-                .toApplePower()
+                .find { totalScore in it.minScore..it.maxScore }
+                ?.toApplePower()
 
             mainCoroutineScope.launch { callback(applePower) }
         }


### PR DESCRIPTION
원격 저장소에서 ApplePower를 불러오지 못하는 문제를 해결함.

먼저 LocalSource에서 ApplePower를 가져올 때, null 이면 remoteSource를 찾게 만들어두었음.
#13 에서 ApplePower를 찾을 때 first()로 찾는 로직이 추가되었음.
초기에는 LocalSource에 ApplePower가 존재하지 않으므로, first()에서 exception이 발생함.
find() 활용으로 nullable하게 변경해서 해결함.

위 내용이 해결 되더라도, 동시성 이슈 떄문에 remoteSource를 두 번 찌르고 있음.
그래서 Room에 저장할 때 id 충돌로 Exception이 발생함.
Dao Insert에 OnConflictStrategy를 REPLACE로 설정해 임시로 해결함

- #17 