### PR TITLE
Repository가 DataSource interface 구현이 아닌, Repository interface 구현으로 변경

### DIFF
--- a/app/src/main/java/com/udtt/applegamsung/config/ViewModelFactory.kt
+++ b/app/src/main/java/com/udtt/applegamsung/config/ViewModelFactory.kt
@@ -2,10 +2,10 @@ package com.udtt.applegamsung.config
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
-import com.udtt.applegamsung.data.repository.CategoriesRepository
 import com.udtt.applegamsung.data.repository.TestResultsRepository
 import com.udtt.applegamsung.data.repository.UserIdentifyRepository
 import com.udtt.applegamsung.domain.repository.AppleBoxItemsRepository
+import com.udtt.applegamsung.domain.repository.CategoriesRepository
 import com.udtt.applegamsung.domain.repository.ProductsRepository
 import com.udtt.applegamsung.ui.applebox.AppleBoxViewModel
 import com.udtt.applegamsung.ui.applepower.ApplePowerViewModel

--- a/app/src/main/java/com/udtt/applegamsung/config/ViewModelFactory.kt
+++ b/app/src/main/java/com/udtt/applegamsung/config/ViewModelFactory.kt
@@ -2,7 +2,11 @@ package com.udtt.applegamsung.config
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
-import com.udtt.applegamsung.data.repository.*
+import com.udtt.applegamsung.data.repository.CategoriesRepository
+import com.udtt.applegamsung.data.repository.ProductsRepository
+import com.udtt.applegamsung.data.repository.TestResultsRepository
+import com.udtt.applegamsung.data.repository.UserIdentifyRepository
+import com.udtt.applegamsung.domain.repository.AppleBoxItemsRepository
 import com.udtt.applegamsung.ui.applebox.AppleBoxViewModel
 import com.udtt.applegamsung.ui.applepower.ApplePowerViewModel
 import com.udtt.applegamsung.ui.intro.IntroViewModel

--- a/app/src/main/java/com/udtt/applegamsung/config/ViewModelFactory.kt
+++ b/app/src/main/java/com/udtt/applegamsung/config/ViewModelFactory.kt
@@ -2,11 +2,11 @@ package com.udtt.applegamsung.config
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
-import com.udtt.applegamsung.data.repository.TestResultsRepository
 import com.udtt.applegamsung.data.repository.UserIdentifyRepository
 import com.udtt.applegamsung.domain.repository.AppleBoxItemsRepository
 import com.udtt.applegamsung.domain.repository.CategoriesRepository
 import com.udtt.applegamsung.domain.repository.ProductsRepository
+import com.udtt.applegamsung.domain.repository.TestResultsRepository
 import com.udtt.applegamsung.ui.applebox.AppleBoxViewModel
 import com.udtt.applegamsung.ui.applepower.ApplePowerViewModel
 import com.udtt.applegamsung.ui.intro.IntroViewModel

--- a/app/src/main/java/com/udtt/applegamsung/config/ViewModelFactory.kt
+++ b/app/src/main/java/com/udtt/applegamsung/config/ViewModelFactory.kt
@@ -3,10 +3,10 @@ package com.udtt.applegamsung.config
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import com.udtt.applegamsung.data.repository.CategoriesRepository
-import com.udtt.applegamsung.data.repository.ProductsRepository
 import com.udtt.applegamsung.data.repository.TestResultsRepository
 import com.udtt.applegamsung.data.repository.UserIdentifyRepository
 import com.udtt.applegamsung.domain.repository.AppleBoxItemsRepository
+import com.udtt.applegamsung.domain.repository.ProductsRepository
 import com.udtt.applegamsung.ui.applebox.AppleBoxViewModel
 import com.udtt.applegamsung.ui.applepower.ApplePowerViewModel
 import com.udtt.applegamsung.ui.intro.IntroViewModel

--- a/app/src/main/java/com/udtt/applegamsung/config/di/DatabaseModule.kt
+++ b/app/src/main/java/com/udtt/applegamsung/config/di/DatabaseModule.kt
@@ -4,8 +4,8 @@ import androidx.room.Room
 import com.google.firebase.firestore.FirebaseFirestore
 import com.udtt.applegamsung.data.database.AppDatabase
 import com.udtt.applegamsung.data.database.migration.AppleProductEntityMigration
-import com.udtt.applegamsung.data.repository.CategoriesRepository
 import com.udtt.applegamsung.data.repository.DefaultAppleBoxItemsRepository
+import com.udtt.applegamsung.data.repository.DefaultCategoriesRepository
 import com.udtt.applegamsung.data.repository.DefaultProductsRepository
 import com.udtt.applegamsung.data.repository.TestResultsRepository
 import com.udtt.applegamsung.data.repository.UserIdentifyRepository
@@ -17,6 +17,7 @@ import com.udtt.applegamsung.data.source.remote.CategoriesRemoteDataSource
 import com.udtt.applegamsung.data.source.remote.ProductsRemoteDataSource
 import com.udtt.applegamsung.data.source.remote.TestResultsRemoteDataSource
 import com.udtt.applegamsung.domain.repository.AppleBoxItemsRepository
+import com.udtt.applegamsung.domain.repository.CategoriesRepository
 import com.udtt.applegamsung.domain.repository.ProductsRepository
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -84,8 +85,8 @@ val remoteDataSourceModule = module {
 
 val repositoryModule = module {
     single { UserIdentifyRepository(androidContext()) }
-    single {
-        CategoriesRepository(
+    single<CategoriesRepository> {
+        DefaultCategoriesRepository(
             get<CategoriesRemoteDataSource>(),
             get<CategoriesLocalDataSource>()
         )

--- a/app/src/main/java/com/udtt/applegamsung/config/di/DatabaseModule.kt
+++ b/app/src/main/java/com/udtt/applegamsung/config/di/DatabaseModule.kt
@@ -4,8 +4,8 @@ import androidx.room.Room
 import com.google.firebase.firestore.FirebaseFirestore
 import com.udtt.applegamsung.data.database.AppDatabase
 import com.udtt.applegamsung.data.database.migration.AppleProductEntityMigration
-import com.udtt.applegamsung.data.repository.AppleBoxItemsRepository
 import com.udtt.applegamsung.data.repository.CategoriesRepository
+import com.udtt.applegamsung.data.repository.DefaultAppleBoxItemsRepository
 import com.udtt.applegamsung.data.repository.ProductsRepository
 import com.udtt.applegamsung.data.repository.TestResultsRepository
 import com.udtt.applegamsung.data.repository.UserIdentifyRepository
@@ -16,6 +16,7 @@ import com.udtt.applegamsung.data.source.local.TestResultsLocalDataSource
 import com.udtt.applegamsung.data.source.remote.CategoriesRemoteDataSource
 import com.udtt.applegamsung.data.source.remote.ProductsRemoteDataSource
 import com.udtt.applegamsung.data.source.remote.TestResultsRemoteDataSource
+import com.udtt.applegamsung.domain.repository.AppleBoxItemsRepository
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import org.koin.android.ext.koin.androidContext
@@ -101,8 +102,8 @@ val repositoryModule = module {
             get<TestResultsLocalDataSource>()
         )
     }
-    single {
-        AppleBoxItemsRepository(
+    single<AppleBoxItemsRepository> {
+        DefaultAppleBoxItemsRepository(
             get<AppleBoxItemsLocalDataSource>()
         )
     }

--- a/app/src/main/java/com/udtt/applegamsung/config/di/DatabaseModule.kt
+++ b/app/src/main/java/com/udtt/applegamsung/config/di/DatabaseModule.kt
@@ -6,7 +6,7 @@ import com.udtt.applegamsung.data.database.AppDatabase
 import com.udtt.applegamsung.data.database.migration.AppleProductEntityMigration
 import com.udtt.applegamsung.data.repository.CategoriesRepository
 import com.udtt.applegamsung.data.repository.DefaultAppleBoxItemsRepository
-import com.udtt.applegamsung.data.repository.ProductsRepository
+import com.udtt.applegamsung.data.repository.DefaultProductsRepository
 import com.udtt.applegamsung.data.repository.TestResultsRepository
 import com.udtt.applegamsung.data.repository.UserIdentifyRepository
 import com.udtt.applegamsung.data.source.local.AppleBoxItemsLocalDataSource
@@ -17,6 +17,7 @@ import com.udtt.applegamsung.data.source.remote.CategoriesRemoteDataSource
 import com.udtt.applegamsung.data.source.remote.ProductsRemoteDataSource
 import com.udtt.applegamsung.data.source.remote.TestResultsRemoteDataSource
 import com.udtt.applegamsung.domain.repository.AppleBoxItemsRepository
+import com.udtt.applegamsung.domain.repository.ProductsRepository
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import org.koin.android.ext.koin.androidContext
@@ -89,8 +90,8 @@ val repositoryModule = module {
             get<CategoriesLocalDataSource>()
         )
     }
-    single {
-        ProductsRepository(
+    single<ProductsRepository> {
+        DefaultProductsRepository(
             get<ProductsRemoteDataSource>(),
             get<ProductsLocalDataSource>(),
             get<AppleBoxItemsLocalDataSource>()

--- a/app/src/main/java/com/udtt/applegamsung/config/di/DatabaseModule.kt
+++ b/app/src/main/java/com/udtt/applegamsung/config/di/DatabaseModule.kt
@@ -7,7 +7,7 @@ import com.udtt.applegamsung.data.database.migration.AppleProductEntityMigration
 import com.udtt.applegamsung.data.repository.DefaultAppleBoxItemsRepository
 import com.udtt.applegamsung.data.repository.DefaultCategoriesRepository
 import com.udtt.applegamsung.data.repository.DefaultProductsRepository
-import com.udtt.applegamsung.data.repository.TestResultsRepository
+import com.udtt.applegamsung.data.repository.DefaultTestResultsRepository
 import com.udtt.applegamsung.data.repository.UserIdentifyRepository
 import com.udtt.applegamsung.data.source.local.AppleBoxItemsLocalDataSource
 import com.udtt.applegamsung.data.source.local.CategoriesLocalDataSource
@@ -19,6 +19,7 @@ import com.udtt.applegamsung.data.source.remote.TestResultsRemoteDataSource
 import com.udtt.applegamsung.domain.repository.AppleBoxItemsRepository
 import com.udtt.applegamsung.domain.repository.CategoriesRepository
 import com.udtt.applegamsung.domain.repository.ProductsRepository
+import com.udtt.applegamsung.domain.repository.TestResultsRepository
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import org.koin.android.ext.koin.androidContext
@@ -98,8 +99,8 @@ val repositoryModule = module {
             get<AppleBoxItemsLocalDataSource>()
         )
     }
-    single {
-        TestResultsRepository(
+    single<TestResultsRepository> {
+        DefaultTestResultsRepository(
             get<TestResultsRemoteDataSource>(),
             get<TestResultsLocalDataSource>()
         )

--- a/app/src/main/java/com/udtt/applegamsung/data/repository/DefaultAppleBoxItemsRepository.kt
+++ b/app/src/main/java/com/udtt/applegamsung/data/repository/DefaultAppleBoxItemsRepository.kt
@@ -2,10 +2,11 @@ package com.udtt.applegamsung.data.repository
 
 import com.udtt.applegamsung.data.entity.AppleBoxItem
 import com.udtt.applegamsung.data.source.AppleBoxItemsDataSource
+import com.udtt.applegamsung.domain.repository.AppleBoxItemsRepository
 
-class AppleBoxItemsRepository(
+class DefaultAppleBoxItemsRepository(
     private val appleBoxItemsLocalDataSource: AppleBoxItemsDataSource
-) : AppleBoxItemsDataSource {
+) : AppleBoxItemsRepository {
 
     override fun getAppleBoxItems(callback: (appleBoxItems: List<AppleBoxItem>) -> Unit) {
         appleBoxItemsLocalDataSource.getAppleBoxItems { callback(it) }

--- a/app/src/main/java/com/udtt/applegamsung/data/repository/DefaultCategoriesRepository.kt
+++ b/app/src/main/java/com/udtt/applegamsung/data/repository/DefaultCategoriesRepository.kt
@@ -2,6 +2,7 @@ package com.udtt.applegamsung.data.repository
 
 import com.udtt.applegamsung.data.entity.Category
 import com.udtt.applegamsung.data.source.CategoriesDataSource
+import com.udtt.applegamsung.domain.repository.CategoriesRepository
 import com.udtt.applegamsung.util.log
 
 /**
@@ -9,10 +10,10 @@ import com.udtt.applegamsung.util.log
  * on 3월 15, 2020
  */
 
-class CategoriesRepository(
+class DefaultCategoriesRepository(
     private val categoriesRemoteDataSource: CategoriesDataSource,
     private val categoriesLocalDataSource: CategoriesDataSource
-) : CategoriesDataSource {
+) : CategoriesRepository {
 
     override fun getCategories(callback: (categories: List<Category>) -> Unit) {
         categoriesLocalDataSource.getCategories {
@@ -33,5 +34,4 @@ class CategoriesRepository(
             saveCategories(it)
         }
     }
-
 }

--- a/app/src/main/java/com/udtt/applegamsung/data/repository/DefaultProductsRepository.kt
+++ b/app/src/main/java/com/udtt/applegamsung/data/repository/DefaultProductsRepository.kt
@@ -5,12 +5,13 @@ import com.udtt.applegamsung.data.entity.DisplayedProduct
 import com.udtt.applegamsung.data.entity.Product
 import com.udtt.applegamsung.data.source.AppleBoxItemsDataSource
 import com.udtt.applegamsung.data.source.ProductsDataSource
+import com.udtt.applegamsung.domain.repository.ProductsRepository
 
-class ProductsRepository(
+class DefaultProductsRepository(
     private val productsRemoteDataSource: ProductsDataSource,
     private val productsLocalDataSource: ProductsDataSource,
     private val appleBoxItemsLocalDataSource: AppleBoxItemsDataSource
-) : ProductsDataSource {
+) : ProductsRepository {
 
     override fun getProducts(categoryId: String, callback: (products: List<Product>) -> Unit) {
         productsLocalDataSource.getProducts(categoryId) {
@@ -34,7 +35,7 @@ class ProductsRepository(
     }
 
     // 워 이 개극혐 소스를 어케 바꿔야하지 ? 콜백헬 개극혐이넹... RxJava를 할줄 모르는게 한이다...
-    fun getDisplayedProducts(
+    override fun getDisplayedProducts(
         categoryId: String,
         callback: (products: List<DisplayedProduct>) -> Unit
     ) {

--- a/app/src/main/java/com/udtt/applegamsung/data/repository/DefaultTestResultsRepository.kt
+++ b/app/src/main/java/com/udtt/applegamsung/data/repository/DefaultTestResultsRepository.kt
@@ -3,6 +3,7 @@ package com.udtt.applegamsung.data.repository
 import com.udtt.applegamsung.data.entity.ApplePower
 import com.udtt.applegamsung.data.entity.TestResult
 import com.udtt.applegamsung.data.source.TestResultsDataSource
+import com.udtt.applegamsung.domain.repository.TestResultsRepository
 import com.udtt.applegamsung.util.log
 
 /**
@@ -10,10 +11,10 @@ import com.udtt.applegamsung.util.log
  * on 3월 22, 2020
  */
 
-class TestResultsRepository(
+class DefaultTestResultsRepository(
     private val testResultsRemoteDataSource: TestResultsDataSource,
     private val testResultsLocalDataSource: TestResultsDataSource
-) : TestResultsDataSource {
+) : TestResultsRepository {
 
     override fun getTestResults(callback: (testResults: List<TestResult>) -> Unit) {
         testResultsLocalDataSource.getTestResults { callback(it) }

--- a/app/src/main/java/com/udtt/applegamsung/domain/repository/AppleBoxItemsRepository.kt
+++ b/app/src/main/java/com/udtt/applegamsung/domain/repository/AppleBoxItemsRepository.kt
@@ -1,0 +1,16 @@
+package com.udtt.applegamsung.domain.repository
+
+import com.udtt.applegamsung.data.entity.AppleBoxItem
+
+interface AppleBoxItemsRepository {
+
+    fun getAppleBoxItems(callback: (appleBoxItems: List<AppleBoxItem>) -> Unit)
+
+    fun saveAppleBoxItems(appleBoxItems: List<AppleBoxItem>)
+
+    fun removeAppleBoxItem(itemToRemove: AppleBoxItem)
+
+    fun removeAppleBoxItems(itemsToRemove: List<AppleBoxItem>)
+
+    fun removeAllAppleBoxItems()
+}

--- a/app/src/main/java/com/udtt/applegamsung/domain/repository/CategoriesRepository.kt
+++ b/app/src/main/java/com/udtt/applegamsung/domain/repository/CategoriesRepository.kt
@@ -1,0 +1,10 @@
+package com.udtt.applegamsung.domain.repository
+
+import com.udtt.applegamsung.data.entity.Category
+
+interface CategoriesRepository {
+
+    fun getCategories(callback: (categories: List<Category>) -> Unit)
+
+    fun saveCategories(categories: List<Category>)
+}

--- a/app/src/main/java/com/udtt/applegamsung/domain/repository/ProductsRepository.kt
+++ b/app/src/main/java/com/udtt/applegamsung/domain/repository/ProductsRepository.kt
@@ -1,0 +1,16 @@
+package com.udtt.applegamsung.domain.repository
+
+import com.udtt.applegamsung.data.entity.DisplayedProduct
+import com.udtt.applegamsung.data.entity.Product
+
+interface ProductsRepository {
+
+    fun getProducts(categoryId: String, callback: (products: List<Product>) -> Unit)
+
+    fun saveProducts(products: List<Product>)
+
+    fun getDisplayedProducts(
+        categoryId: String,
+        callback: (products: List<DisplayedProduct>) -> Unit
+    )
+}

--- a/app/src/main/java/com/udtt/applegamsung/domain/repository/TestResultsRepository.kt
+++ b/app/src/main/java/com/udtt/applegamsung/domain/repository/TestResultsRepository.kt
@@ -1,0 +1,24 @@
+package com.udtt.applegamsung.domain.repository
+
+import com.udtt.applegamsung.data.entity.ApplePower
+import com.udtt.applegamsung.data.entity.TestResult
+
+/**
+ * Created By Yun Hyeok
+ * on 3월 21, 2020
+ */
+
+interface TestResultsRepository {
+
+    fun getTestResults(callback: (testResults: List<TestResult>) -> Unit)
+
+    fun saveTestResult(testResult: TestResult)
+
+    fun removeAllTestResults()
+
+    fun getApplePowers(callback: (applePowers: List<ApplePower>) -> Unit)
+
+    fun getApplePower(totalScore: Int, callback: (applePower: ApplePower?) -> Unit)
+
+    fun saveApplePowers(applePowers: List<ApplePower>)
+}

--- a/app/src/main/java/com/udtt/applegamsung/ui/applebox/AppleBoxViewModel.kt
+++ b/app/src/main/java/com/udtt/applegamsung/ui/applebox/AppleBoxViewModel.kt
@@ -3,8 +3,8 @@ package com.udtt.applegamsung.ui.applebox
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import com.udtt.applegamsung.data.entity.AppleBoxItem
-import com.udtt.applegamsung.data.repository.AppleBoxItemsRepository
 import com.udtt.applegamsung.data.repository.UserIdentifyRepository
+import com.udtt.applegamsung.domain.repository.AppleBoxItemsRepository
 import com.udtt.applegamsung.util.BaseViewModel
 
 class AppleBoxViewModel(

--- a/app/src/main/java/com/udtt/applegamsung/ui/applepower/ApplePowerViewModel.kt
+++ b/app/src/main/java/com/udtt/applegamsung/ui/applepower/ApplePowerViewModel.kt
@@ -6,9 +6,9 @@ import com.udtt.applegamsung.data.entity.AppleBoxItem
 import com.udtt.applegamsung.data.entity.ApplePower
 import com.udtt.applegamsung.data.entity.Category
 import com.udtt.applegamsung.data.entity.TestResult
-import com.udtt.applegamsung.data.repository.AppleBoxItemsRepository
 import com.udtt.applegamsung.data.repository.TestResultsRepository
 import com.udtt.applegamsung.data.repository.UserIdentifyRepository
+import com.udtt.applegamsung.domain.repository.AppleBoxItemsRepository
 import com.udtt.applegamsung.util.BaseViewModel
 
 class ApplePowerViewModel(

--- a/app/src/main/java/com/udtt/applegamsung/ui/applepower/ApplePowerViewModel.kt
+++ b/app/src/main/java/com/udtt/applegamsung/ui/applepower/ApplePowerViewModel.kt
@@ -6,9 +6,9 @@ import com.udtt.applegamsung.data.entity.AppleBoxItem
 import com.udtt.applegamsung.data.entity.ApplePower
 import com.udtt.applegamsung.data.entity.Category
 import com.udtt.applegamsung.data.entity.TestResult
-import com.udtt.applegamsung.data.repository.TestResultsRepository
 import com.udtt.applegamsung.data.repository.UserIdentifyRepository
 import com.udtt.applegamsung.domain.repository.AppleBoxItemsRepository
+import com.udtt.applegamsung.domain.repository.TestResultsRepository
 import com.udtt.applegamsung.util.BaseViewModel
 
 class ApplePowerViewModel(

--- a/app/src/main/java/com/udtt/applegamsung/ui/intro/IntroViewModel.kt
+++ b/app/src/main/java/com/udtt/applegamsung/ui/intro/IntroViewModel.kt
@@ -1,10 +1,10 @@
 package com.udtt.applegamsung.ui.intro
 
-import com.udtt.applegamsung.data.repository.TestResultsRepository
 import com.udtt.applegamsung.data.repository.UserIdentifyRepository
+import com.udtt.applegamsung.domain.repository.TestResultsRepository
 import com.udtt.applegamsung.util.BaseViewModel
 import com.udtt.applegamsung.util.log
-import java.util.*
+import java.util.UUID
 
 /**
  * Created By Yun Hyeok

--- a/app/src/main/java/com/udtt/applegamsung/ui/main/MainViewModel.kt
+++ b/app/src/main/java/com/udtt/applegamsung/ui/main/MainViewModel.kt
@@ -7,7 +7,7 @@ import com.udtt.applegamsung.data.entity.AppleBoxItem
 import com.udtt.applegamsung.data.entity.Category
 import com.udtt.applegamsung.data.entity.Product
 import com.udtt.applegamsung.data.entity.SelectedProduct
-import com.udtt.applegamsung.data.repository.AppleBoxItemsRepository
+import com.udtt.applegamsung.domain.repository.AppleBoxItemsRepository
 import com.udtt.applegamsung.ui.main.adapter.MainViewPagerAdapter.Companion.FRAGMENT_CATEGORIES
 import com.udtt.applegamsung.ui.main.adapter.MainViewPagerAdapter.Companion.FRAGMENT_NICKNAME
 import com.udtt.applegamsung.ui.main.adapter.MainViewPagerAdapter.Companion.FRAGMENT_PRODUCTS

--- a/app/src/main/java/com/udtt/applegamsung/ui/main/categories/CategoriesViewModel.kt
+++ b/app/src/main/java/com/udtt/applegamsung/ui/main/categories/CategoriesViewModel.kt
@@ -3,7 +3,7 @@ package com.udtt.applegamsung.ui.main.categories
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import com.udtt.applegamsung.data.entity.Category
-import com.udtt.applegamsung.data.repository.CategoriesRepository
+import com.udtt.applegamsung.domain.repository.CategoriesRepository
 import com.udtt.applegamsung.util.BaseViewModel
 
 class CategoriesViewModel(

--- a/app/src/main/java/com/udtt/applegamsung/ui/main/products/ProductsViewModel.kt
+++ b/app/src/main/java/com/udtt/applegamsung/ui/main/products/ProductsViewModel.kt
@@ -4,7 +4,7 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import com.udtt.applegamsung.data.entity.DisplayedProduct
 import com.udtt.applegamsung.data.entity.Product
-import com.udtt.applegamsung.data.repository.ProductsRepository
+import com.udtt.applegamsung.domain.repository.ProductsRepository
 import com.udtt.applegamsung.util.BaseViewModel
 
 class ProductsViewModel(


### PR DESCRIPTION
기존에는 Repository또한 DataSource중 하나로 취급해서 Repository가 DataSource interface를 상속받았음.
Repository 모듈 분리를 수월하게 하기 위해 Repository interface를 생성 후 상속받도록 변경하고자 함.

기존 Repository 구현체는 Default 접두사를 붙이도록 구현함.

- close #10 