### PR TITLE
도메인 모델에서 firestore 의존성 제거

### DIFF
--- a/app/src/main/java/com/udtt/applegamsung/data/entity/AppleBoxItem.kt
+++ b/app/src/main/java/com/udtt/applegamsung/data/entity/AppleBoxItem.kt
@@ -1,5 +1,6 @@
 package com.udtt.applegamsung.data.entity
 
+import com.udtt.applegamsung.domain.model.product.Product
 import java.util.*
 
 data class AppleBoxItem(

--- a/app/src/main/java/com/udtt/applegamsung/data/entity/DisplayedProduct.kt
+++ b/app/src/main/java/com/udtt/applegamsung/data/entity/DisplayedProduct.kt
@@ -1,5 +1,7 @@
 package com.udtt.applegamsung.data.entity
 
+import com.udtt.applegamsung.domain.model.product.Product
+
 data class DisplayedProduct(
     val product: Product,
     var isSelected: Boolean = false,

--- a/app/src/main/java/com/udtt/applegamsung/data/entity/SelectedProduct.kt
+++ b/app/src/main/java/com/udtt/applegamsung/data/entity/SelectedProduct.kt
@@ -1,5 +1,7 @@
 package com.udtt.applegamsung.data.entity
 
+import com.udtt.applegamsung.domain.model.product.Product
+
 /**
  * Created By Yun Hyeok
  * on 3월 27, 2020

--- a/app/src/main/java/com/udtt/applegamsung/data/local/mapper/ApplePowerEntityMapper.kt
+++ b/app/src/main/java/com/udtt/applegamsung/data/local/mapper/ApplePowerEntityMapper.kt
@@ -1,6 +1,6 @@
 package com.udtt.applegamsung.data.local.mapper
 
-import com.udtt.applegamsung.data.entity.ApplePower
+import com.udtt.applegamsung.domain.model.testresult.applepower.ApplePower
 import com.udtt.applegamsung.data.entity.ApplePowerEntity
 
 fun ApplePowerEntity.toApplePower(): ApplePower {

--- a/app/src/main/java/com/udtt/applegamsung/data/local/mapper/AppleProductCategoryEntityMapper.kt
+++ b/app/src/main/java/com/udtt/applegamsung/data/local/mapper/AppleProductCategoryEntityMapper.kt
@@ -1,7 +1,7 @@
 package com.udtt.applegamsung.data.local.mapper
 
 import com.udtt.applegamsung.data.entity.AppleProductCategoryEntity
-import com.udtt.applegamsung.data.entity.Category
+import com.udtt.applegamsung.domain.model.category.Category
 
 fun AppleProductCategoryEntity.toCategory(): Category {
     return Category(

--- a/app/src/main/java/com/udtt/applegamsung/data/local/mapper/AppleProductEntityMapper.kt
+++ b/app/src/main/java/com/udtt/applegamsung/data/local/mapper/AppleProductEntityMapper.kt
@@ -9,6 +9,7 @@ fun AppleProductEntity.toProduct(): Product {
         score = score,
         categoryIndex = sortPriority,
         categoryId = appleProductCategoryId,
+        imageUrl = "",
         id = id,
     )
 }

--- a/app/src/main/java/com/udtt/applegamsung/data/local/mapper/AppleProductEntityMapper.kt
+++ b/app/src/main/java/com/udtt/applegamsung/data/local/mapper/AppleProductEntityMapper.kt
@@ -1,7 +1,7 @@
 package com.udtt.applegamsung.data.local.mapper
 
 import com.udtt.applegamsung.data.entity.AppleProductEntity
-import com.udtt.applegamsung.data.entity.Product
+import com.udtt.applegamsung.domain.model.product.Product
 
 fun AppleProductEntity.toProduct(): Product {
     return Product(

--- a/app/src/main/java/com/udtt/applegamsung/data/local/mapper/TestResultEntityMapper.kt
+++ b/app/src/main/java/com/udtt/applegamsung/data/local/mapper/TestResultEntityMapper.kt
@@ -1,13 +1,14 @@
 package com.udtt.applegamsung.data.local.mapper
 
-import com.udtt.applegamsung.domain.model.testresult.TestResult
 import com.udtt.applegamsung.data.entity.TestResultEntity
+import com.udtt.applegamsung.domain.model.testresult.TestResult
 
 fun TestResultEntity.toTestResult(): TestResult {
     return TestResult(
         deviceId = deviceId,
         nickname = nickname,
         totalScore = totalScore,
+        productList = emptyList(),
         timeStamp = timeStamp,
         id = id,
     )

--- a/app/src/main/java/com/udtt/applegamsung/data/local/mapper/TestResultEntityMapper.kt
+++ b/app/src/main/java/com/udtt/applegamsung/data/local/mapper/TestResultEntityMapper.kt
@@ -1,6 +1,6 @@
 package com.udtt.applegamsung.data.local.mapper
 
-import com.udtt.applegamsung.data.entity.TestResult
+import com.udtt.applegamsung.domain.model.testresult.TestResult
 import com.udtt.applegamsung.data.entity.TestResultEntity
 
 fun TestResultEntity.toTestResult(): TestResult {

--- a/app/src/main/java/com/udtt/applegamsung/data/remote/mapper/SaveTestResultParamsMapper.kt
+++ b/app/src/main/java/com/udtt/applegamsung/data/remote/mapper/SaveTestResultParamsMapper.kt
@@ -1,0 +1,14 @@
+package com.udtt.applegamsung.data.remote.mapper
+
+import com.udtt.applegamsung.data.remote.params.SaveTestResultParams
+import com.udtt.applegamsung.domain.model.testresult.TestResult
+
+fun TestResult.toSaveResultParams(): SaveTestResultParams {
+    return SaveTestResultParams(
+        deviceId = deviceId,
+        nickname = nickname,
+        totalScore = totalScore,
+        timeStamp = timeStamp,
+        productList = productList,
+    )
+}

--- a/app/src/main/java/com/udtt/applegamsung/data/remote/params/SaveTestResultParams.kt
+++ b/app/src/main/java/com/udtt/applegamsung/data/remote/params/SaveTestResultParams.kt
@@ -1,17 +1,13 @@
-package com.udtt.applegamsung.domain.model.testresult
+package com.udtt.applegamsung.data.remote.params
 
+import com.google.firebase.firestore.ServerTimestamp
 import java.util.Date
 
-/**
- * Created By Yun Hyeok
- * on 3월 14, 2020
- */
-
-data class TestResult(
+data class SaveTestResultParams(
     val deviceId: String,
     val nickname: String,
     val totalScore: Int,
+    @ServerTimestamp
     val productList: List<String>,
     val timeStamp: Date,
-    val id: String,
 )

--- a/app/src/main/java/com/udtt/applegamsung/data/repository/DefaultCategoriesRepository.kt
+++ b/app/src/main/java/com/udtt/applegamsung/data/repository/DefaultCategoriesRepository.kt
@@ -1,6 +1,6 @@
 package com.udtt.applegamsung.data.repository
 
-import com.udtt.applegamsung.data.entity.Category
+import com.udtt.applegamsung.domain.model.category.Category
 import com.udtt.applegamsung.data.source.CategoriesDataSource
 import com.udtt.applegamsung.domain.repository.CategoriesRepository
 import com.udtt.applegamsung.util.getOrEmpty

--- a/app/src/main/java/com/udtt/applegamsung/data/repository/DefaultProductsRepository.kt
+++ b/app/src/main/java/com/udtt/applegamsung/data/repository/DefaultProductsRepository.kt
@@ -1,7 +1,7 @@
 package com.udtt.applegamsung.data.repository
 
 import com.udtt.applegamsung.data.entity.DisplayedProduct
-import com.udtt.applegamsung.data.entity.Product
+import com.udtt.applegamsung.domain.model.product.Product
 import com.udtt.applegamsung.data.source.AppleBoxItemsDataSource
 import com.udtt.applegamsung.data.source.ProductsDataSource
 import com.udtt.applegamsung.domain.repository.ProductsRepository

--- a/app/src/main/java/com/udtt/applegamsung/data/repository/DefaultTestResultsRepository.kt
+++ b/app/src/main/java/com/udtt/applegamsung/data/repository/DefaultTestResultsRepository.kt
@@ -1,7 +1,7 @@
 package com.udtt.applegamsung.data.repository
 
-import com.udtt.applegamsung.data.entity.ApplePower
-import com.udtt.applegamsung.data.entity.TestResult
+import com.udtt.applegamsung.domain.model.testresult.applepower.ApplePower
+import com.udtt.applegamsung.domain.model.testresult.TestResult
 import com.udtt.applegamsung.data.source.TestResultsDataSource
 import com.udtt.applegamsung.domain.repository.TestResultsRepository
 import com.udtt.applegamsung.util.getOrEmpty

--- a/app/src/main/java/com/udtt/applegamsung/data/source/CategoriesDataSource.kt
+++ b/app/src/main/java/com/udtt/applegamsung/data/source/CategoriesDataSource.kt
@@ -1,6 +1,6 @@
 package com.udtt.applegamsung.data.source
 
-import com.udtt.applegamsung.data.entity.Category
+import com.udtt.applegamsung.domain.model.category.Category
 
 /**
  * Created By Yun Hyeok

--- a/app/src/main/java/com/udtt/applegamsung/data/source/ProductsDataSource.kt
+++ b/app/src/main/java/com/udtt/applegamsung/data/source/ProductsDataSource.kt
@@ -1,6 +1,6 @@
 package com.udtt.applegamsung.data.source
 
-import com.udtt.applegamsung.data.entity.Product
+import com.udtt.applegamsung.domain.model.product.Product
 
 /**
  * Created By Yun Hyeok

--- a/app/src/main/java/com/udtt/applegamsung/data/source/TestResultsDataSource.kt
+++ b/app/src/main/java/com/udtt/applegamsung/data/source/TestResultsDataSource.kt
@@ -1,7 +1,7 @@
 package com.udtt.applegamsung.data.source
 
-import com.udtt.applegamsung.data.entity.ApplePower
-import com.udtt.applegamsung.data.entity.TestResult
+import com.udtt.applegamsung.domain.model.testresult.applepower.ApplePower
+import com.udtt.applegamsung.domain.model.testresult.TestResult
 
 /**
  * Created By Yun Hyeok

--- a/app/src/main/java/com/udtt/applegamsung/data/source/local/LocalCategoriesDataSource.kt
+++ b/app/src/main/java/com/udtt/applegamsung/data/source/local/LocalCategoriesDataSource.kt
@@ -1,7 +1,7 @@
 package com.udtt.applegamsung.data.source.local
 
 import com.udtt.applegamsung.data.dao.AppleProductCategoriesDao
-import com.udtt.applegamsung.data.entity.Category
+import com.udtt.applegamsung.domain.model.category.Category
 import com.udtt.applegamsung.data.local.mapper.toAppleProductCategoryEntity
 import com.udtt.applegamsung.data.local.mapper.toCategory
 import com.udtt.applegamsung.data.source.CategoriesDataSource

--- a/app/src/main/java/com/udtt/applegamsung/data/source/local/LocalProductsDataSource.kt
+++ b/app/src/main/java/com/udtt/applegamsung/data/source/local/LocalProductsDataSource.kt
@@ -1,7 +1,7 @@
 package com.udtt.applegamsung.data.source.local
 
 import com.udtt.applegamsung.data.dao.AppleProductsDao
-import com.udtt.applegamsung.data.entity.Product
+import com.udtt.applegamsung.domain.model.product.Product
 import com.udtt.applegamsung.data.local.mapper.toAppleProductEntity
 import com.udtt.applegamsung.data.local.mapper.toProduct
 import com.udtt.applegamsung.data.source.ProductsDataSource

--- a/app/src/main/java/com/udtt/applegamsung/data/source/local/LocalTestResultsDataSource.kt
+++ b/app/src/main/java/com/udtt/applegamsung/data/source/local/LocalTestResultsDataSource.kt
@@ -2,8 +2,8 @@ package com.udtt.applegamsung.data.source.local
 
 import com.udtt.applegamsung.data.dao.ApplePowersDao
 import com.udtt.applegamsung.data.dao.TestResultsDao
-import com.udtt.applegamsung.data.entity.ApplePower
-import com.udtt.applegamsung.data.entity.TestResult
+import com.udtt.applegamsung.domain.model.testresult.applepower.ApplePower
+import com.udtt.applegamsung.domain.model.testresult.TestResult
 import com.udtt.applegamsung.data.local.mapper.toApplePower
 import com.udtt.applegamsung.data.local.mapper.toApplePowerEntity
 import com.udtt.applegamsung.data.local.mapper.toTestResult

--- a/app/src/main/java/com/udtt/applegamsung/data/source/remote/RemoteCategoriesDataSource.kt
+++ b/app/src/main/java/com/udtt/applegamsung/data/source/remote/RemoteCategoriesDataSource.kt
@@ -1,7 +1,7 @@
 package com.udtt.applegamsung.data.source.remote
 
 import com.google.firebase.firestore.FirebaseFirestore
-import com.udtt.applegamsung.data.entity.Category
+import com.udtt.applegamsung.domain.model.category.Category
 import com.udtt.applegamsung.data.remote.firestore.getDocumentSnapshots
 import com.udtt.applegamsung.data.source.CategoriesDataSource
 

--- a/app/src/main/java/com/udtt/applegamsung/data/source/remote/RemoteProductsDataSource.kt
+++ b/app/src/main/java/com/udtt/applegamsung/data/source/remote/RemoteProductsDataSource.kt
@@ -1,7 +1,7 @@
 package com.udtt.applegamsung.data.source.remote
 
 import com.google.firebase.firestore.FirebaseFirestore
-import com.udtt.applegamsung.data.entity.Product
+import com.udtt.applegamsung.domain.model.product.Product
 import com.udtt.applegamsung.data.remote.firestore.getDocumentSnapshots
 import com.udtt.applegamsung.data.source.ProductsDataSource
 

--- a/app/src/main/java/com/udtt/applegamsung/data/source/remote/RemoteProductsDataSource.kt
+++ b/app/src/main/java/com/udtt/applegamsung/data/source/remote/RemoteProductsDataSource.kt
@@ -1,9 +1,9 @@
 package com.udtt.applegamsung.data.source.remote
 
 import com.google.firebase.firestore.FirebaseFirestore
-import com.udtt.applegamsung.domain.model.product.Product
 import com.udtt.applegamsung.data.remote.firestore.getDocumentSnapshots
 import com.udtt.applegamsung.data.source.ProductsDataSource
+import com.udtt.applegamsung.domain.model.product.Product
 
 /**
  * Created By Yun Hyeok
@@ -27,6 +27,7 @@ class RemoteProductsDataSource(
                         score = it.getLong("score")?.toInt() ?: 0,
                         categoryIndex = it.getLong("categoryIndex")?.toInt() ?: 0,
                         categoryId = it.getString("categoryId").orEmpty(),
+                        imageUrl = ""
                     )
                 }
             }

--- a/app/src/main/java/com/udtt/applegamsung/data/source/remote/RemoteTestResultsDataSource.kt
+++ b/app/src/main/java/com/udtt/applegamsung/data/source/remote/RemoteTestResultsDataSource.kt
@@ -5,6 +5,7 @@ import com.udtt.applegamsung.domain.model.testresult.applepower.ApplePower
 import com.udtt.applegamsung.domain.model.testresult.TestResult
 import com.udtt.applegamsung.data.remote.firestore.addAwait
 import com.udtt.applegamsung.data.remote.firestore.getDocumentSnapshots
+import com.udtt.applegamsung.data.remote.mapper.toSaveResultParams
 import com.udtt.applegamsung.data.source.TestResultsDataSource
 
 /**
@@ -24,7 +25,7 @@ class RemoteTestResultsDataSource(
 
     override suspend fun saveTestResult(testResult: TestResult): Result<Unit> {
         return firestore.collection(PathTestResults)
-            .addAwait(testResult)
+            .addAwait(testResult.toSaveResultParams())
     }
 
     override suspend fun getApplePowers(): Result<List<ApplePower>> {

--- a/app/src/main/java/com/udtt/applegamsung/data/source/remote/RemoteTestResultsDataSource.kt
+++ b/app/src/main/java/com/udtt/applegamsung/data/source/remote/RemoteTestResultsDataSource.kt
@@ -1,8 +1,8 @@
 package com.udtt.applegamsung.data.source.remote
 
 import com.google.firebase.firestore.FirebaseFirestore
-import com.udtt.applegamsung.data.entity.ApplePower
-import com.udtt.applegamsung.data.entity.TestResult
+import com.udtt.applegamsung.domain.model.testresult.applepower.ApplePower
+import com.udtt.applegamsung.domain.model.testresult.TestResult
 import com.udtt.applegamsung.data.remote.firestore.addAwait
 import com.udtt.applegamsung.data.remote.firestore.getDocumentSnapshots
 import com.udtt.applegamsung.data.source.TestResultsDataSource

--- a/app/src/main/java/com/udtt/applegamsung/domain/model/category/Category.kt
+++ b/app/src/main/java/com/udtt/applegamsung/domain/model/category/Category.kt
@@ -1,4 +1,4 @@
-package com.udtt.applegamsung.data.entity
+package com.udtt.applegamsung.domain.model.category
 
 import androidx.annotation.DrawableRes
 import com.udtt.applegamsung.R

--- a/app/src/main/java/com/udtt/applegamsung/domain/model/product/Product.kt
+++ b/app/src/main/java/com/udtt/applegamsung/domain/model/product/Product.kt
@@ -1,6 +1,8 @@
-package com.udtt.applegamsung.data.entity
+package com.udtt.applegamsung.domain.model.product
 
 import com.google.firebase.firestore.IgnoreExtraProperties
+import com.udtt.applegamsung.domain.model.category.Category
+import com.udtt.applegamsung.data.entity.SelectedProduct
 import java.util.UUID
 
 /**

--- a/app/src/main/java/com/udtt/applegamsung/domain/model/product/Product.kt
+++ b/app/src/main/java/com/udtt/applegamsung/domain/model/product/Product.kt
@@ -1,26 +1,21 @@
 package com.udtt.applegamsung.domain.model.product
 
-import com.google.firebase.firestore.IgnoreExtraProperties
 import com.udtt.applegamsung.domain.model.category.Category
 import com.udtt.applegamsung.data.entity.SelectedProduct
-import java.util.UUID
 
 /**
  * Created By Yun Hyeok
  * on 3월 14, 2020
  */
 
-@IgnoreExtraProperties
 data class Product(
-    val name: String = "",
-    val score: Int = 0,
-    val categoryIndex: Int = 0,
-    var categoryId: String = "",
-    val imageUrl: String = "",
-    val id: String = UUID.randomUUID().toString()
+    val name: String,
+    val score: Int,
+    val categoryIndex: Int,
+    val categoryId: String,
+    val imageUrl: String,
+    val id: String,
 ) {
-    var imageByteArray: ByteArray? = null
-
     val categoryType: Category.Type
         get() = Category.Type.findByIndex(categoryIndex)
 

--- a/app/src/main/java/com/udtt/applegamsung/domain/model/testresult/TestResult.kt
+++ b/app/src/main/java/com/udtt/applegamsung/domain/model/testresult/TestResult.kt
@@ -1,4 +1,4 @@
-package com.udtt.applegamsung.data.entity
+package com.udtt.applegamsung.domain.model.testresult
 
 import com.google.firebase.firestore.IgnoreExtraProperties
 import com.google.firebase.firestore.ServerTimestamp

--- a/app/src/main/java/com/udtt/applegamsung/domain/model/testresult/applepower/ApplePower.kt
+++ b/app/src/main/java/com/udtt/applegamsung/domain/model/testresult/applepower/ApplePower.kt
@@ -1,4 +1,4 @@
-package com.udtt.applegamsung.data.entity
+package com.udtt.applegamsung.domain.model.testresult.applepower
 
 import androidx.annotation.DrawableRes
 import com.udtt.applegamsung.R

--- a/app/src/main/java/com/udtt/applegamsung/domain/repository/CategoriesRepository.kt
+++ b/app/src/main/java/com/udtt/applegamsung/domain/repository/CategoriesRepository.kt
@@ -1,6 +1,6 @@
 package com.udtt.applegamsung.domain.repository
 
-import com.udtt.applegamsung.data.entity.Category
+import com.udtt.applegamsung.domain.model.category.Category
 
 interface CategoriesRepository {
 

--- a/app/src/main/java/com/udtt/applegamsung/domain/repository/ProductsRepository.kt
+++ b/app/src/main/java/com/udtt/applegamsung/domain/repository/ProductsRepository.kt
@@ -1,7 +1,7 @@
 package com.udtt.applegamsung.domain.repository
 
 import com.udtt.applegamsung.data.entity.DisplayedProduct
-import com.udtt.applegamsung.data.entity.Product
+import com.udtt.applegamsung.domain.model.product.Product
 
 interface ProductsRepository {
 

--- a/app/src/main/java/com/udtt/applegamsung/domain/repository/TestResultsRepository.kt
+++ b/app/src/main/java/com/udtt/applegamsung/domain/repository/TestResultsRepository.kt
@@ -1,7 +1,7 @@
 package com.udtt.applegamsung.domain.repository
 
-import com.udtt.applegamsung.data.entity.ApplePower
-import com.udtt.applegamsung.data.entity.TestResult
+import com.udtt.applegamsung.domain.model.testresult.applepower.ApplePower
+import com.udtt.applegamsung.domain.model.testresult.TestResult
 
 /**
  * Created By Yun Hyeok

--- a/app/src/main/java/com/udtt/applegamsung/ui/applepower/ApplePowerViewModel.kt
+++ b/app/src/main/java/com/udtt/applegamsung/ui/applepower/ApplePowerViewModel.kt
@@ -4,14 +4,16 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.viewModelScope
 import com.udtt.applegamsung.data.entity.AppleBoxItem
-import com.udtt.applegamsung.domain.model.testresult.applepower.ApplePower
+import com.udtt.applegamsung.data.repository.UserIdentifyRepository
 import com.udtt.applegamsung.domain.model.category.Category
 import com.udtt.applegamsung.domain.model.testresult.TestResult
-import com.udtt.applegamsung.data.repository.UserIdentifyRepository
+import com.udtt.applegamsung.domain.model.testresult.applepower.ApplePower
 import com.udtt.applegamsung.domain.repository.AppleBoxItemsRepository
 import com.udtt.applegamsung.domain.repository.TestResultsRepository
 import com.udtt.applegamsung.util.BaseViewModel
 import kotlinx.coroutines.launch
+import java.util.Date
+import java.util.UUID
 
 class ApplePowerViewModel(
     userIdentifyRepository: UserIdentifyRepository,
@@ -111,10 +113,13 @@ class ApplePowerViewModel(
         val currentScore = _score.value ?: throw ILLEGAL_STATE_EXCEPTION
         val productList = _havingProducts.value ?: throw ILLEGAL_STATE_EXCEPTION
         return TestResult(
-            deviceId,
-            userNickName,
-            currentScore
-        ).apply { this.productList = productList }
+            deviceId = deviceId,
+            nickname = userNickName,
+            totalScore = currentScore,
+            productList = productList,
+            timeStamp = Date(),
+            id = UUID.randomUUID().toString(),
+        )
     }
 
     private fun saveTestResult() {

--- a/app/src/main/java/com/udtt/applegamsung/ui/applepower/ApplePowerViewModel.kt
+++ b/app/src/main/java/com/udtt/applegamsung/ui/applepower/ApplePowerViewModel.kt
@@ -4,9 +4,9 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.viewModelScope
 import com.udtt.applegamsung.data.entity.AppleBoxItem
-import com.udtt.applegamsung.data.entity.ApplePower
-import com.udtt.applegamsung.data.entity.Category
-import com.udtt.applegamsung.data.entity.TestResult
+import com.udtt.applegamsung.domain.model.testresult.applepower.ApplePower
+import com.udtt.applegamsung.domain.model.category.Category
+import com.udtt.applegamsung.domain.model.testresult.TestResult
 import com.udtt.applegamsung.data.repository.UserIdentifyRepository
 import com.udtt.applegamsung.domain.repository.AppleBoxItemsRepository
 import com.udtt.applegamsung.domain.repository.TestResultsRepository

--- a/app/src/main/java/com/udtt/applegamsung/ui/main/MainViewModel.kt
+++ b/app/src/main/java/com/udtt/applegamsung/ui/main/MainViewModel.kt
@@ -5,8 +5,8 @@ import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.udtt.applegamsung.data.entity.AppleBoxItem
-import com.udtt.applegamsung.data.entity.Category
-import com.udtt.applegamsung.data.entity.Product
+import com.udtt.applegamsung.domain.model.category.Category
+import com.udtt.applegamsung.domain.model.product.Product
 import com.udtt.applegamsung.data.entity.SelectedProduct
 import com.udtt.applegamsung.domain.repository.AppleBoxItemsRepository
 import com.udtt.applegamsung.ui.main.adapter.MainViewPagerAdapter.Companion.FRAGMENT_CATEGORIES

--- a/app/src/main/java/com/udtt/applegamsung/ui/main/categories/CategoriesAdapter.kt
+++ b/app/src/main/java/com/udtt/applegamsung/ui/main/categories/CategoriesAdapter.kt
@@ -4,9 +4,8 @@ import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.lifecycle.LifecycleOwner
 import androidx.recyclerview.widget.RecyclerView
-import com.udtt.applegamsung.data.entity.Category
+import com.udtt.applegamsung.domain.model.category.Category
 import com.udtt.applegamsung.databinding.ItemCategoryBinding
-import com.udtt.applegamsung.ui.main.MainViewModel
 
 class CategoriesAdapter : RecyclerView.Adapter<CategoriesAdapter.ViewHolder>() {
 

--- a/app/src/main/java/com/udtt/applegamsung/ui/main/categories/CategoriesFragment.kt
+++ b/app/src/main/java/com/udtt/applegamsung/ui/main/categories/CategoriesFragment.kt
@@ -6,11 +6,9 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.view.animation.AnimationUtils
 import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProvider
-import com.udtt.applegamsung.R
-import com.udtt.applegamsung.data.entity.Category
+import com.udtt.applegamsung.domain.model.category.Category
 import com.udtt.applegamsung.databinding.FragmentCategoriesBinding
 import com.udtt.applegamsung.ui.applebox.AppleBoxActivity
 import com.udtt.applegamsung.ui.main.MainViewModel

--- a/app/src/main/java/com/udtt/applegamsung/ui/main/categories/CategoriesViewModel.kt
+++ b/app/src/main/java/com/udtt/applegamsung/ui/main/categories/CategoriesViewModel.kt
@@ -3,7 +3,7 @@ package com.udtt.applegamsung.ui.main.categories
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.viewModelScope
-import com.udtt.applegamsung.data.entity.Category
+import com.udtt.applegamsung.domain.model.category.Category
 import com.udtt.applegamsung.domain.repository.CategoriesRepository
 import com.udtt.applegamsung.util.BaseViewModel
 import kotlinx.coroutines.launch

--- a/app/src/main/java/com/udtt/applegamsung/ui/main/categories/CategoryClickListener.kt
+++ b/app/src/main/java/com/udtt/applegamsung/ui/main/categories/CategoryClickListener.kt
@@ -1,6 +1,6 @@
 package com.udtt.applegamsung.ui.main.categories
 
-import com.udtt.applegamsung.data.entity.Category
+import com.udtt.applegamsung.domain.model.category.Category
 
 interface CategoryClickListener {
 

--- a/app/src/main/java/com/udtt/applegamsung/ui/main/products/ProductsAdapter.kt
+++ b/app/src/main/java/com/udtt/applegamsung/ui/main/products/ProductsAdapter.kt
@@ -8,7 +8,6 @@ import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
 import com.udtt.applegamsung.data.entity.DisplayedProduct
-import com.udtt.applegamsung.data.entity.Product
 import com.udtt.applegamsung.databinding.ItemProductBinding
 
 class ProductsAdapter : ListAdapter<DisplayedProduct, ProductsAdapter.ViewHolder>(DiffCallBack()) {

--- a/app/src/main/java/com/udtt/applegamsung/ui/main/products/ProductsViewModel.kt
+++ b/app/src/main/java/com/udtt/applegamsung/ui/main/products/ProductsViewModel.kt
@@ -4,7 +4,7 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.viewModelScope
 import com.udtt.applegamsung.data.entity.DisplayedProduct
-import com.udtt.applegamsung.data.entity.Product
+import com.udtt.applegamsung.domain.model.product.Product
 import com.udtt.applegamsung.domain.repository.ProductsRepository
 import com.udtt.applegamsung.util.BaseViewModel
 import kotlinx.coroutines.launch

--- a/app/src/main/res/layout/activity_apple_power.xml
+++ b/app/src/main/res/layout/activity_apple_power.xml
@@ -5,7 +5,7 @@
 
     <data>
 
-        <import type="com.udtt.applegamsung.data.entity.Category.Type" />
+        <import type="com.udtt.applegamsung.domain.model.category.Category" />
 
         <variable
             name="applePowerViewModel"

--- a/app/src/main/res/layout/activity_apple_power.xml
+++ b/app/src/main/res/layout/activity_apple_power.xml
@@ -5,7 +5,7 @@
 
     <data>
 
-        <import type="com.udtt.applegamsung.domain.model.category.Category" />
+        <import type="com.udtt.applegamsung.domain.model.category.Category.Type" />
 
         <variable
             name="applePowerViewModel"

--- a/app/src/main/res/layout/item_category.xml
+++ b/app/src/main/res/layout/item_category.xml
@@ -6,7 +6,7 @@
 
         <variable
             name="category"
-            type="com.udtt.applegamsung.data.entity.Category" />
+            type="com.udtt.applegamsung.domain.model.category.Category" />
 
         <variable
             name="itemClickListener"


### PR DESCRIPTION
도메인 모델에서 firestore에 대한 의존성을 제거함.
도메인 모델로써 사용하고 있던 모델들을 모두 도메인 패키지로 이동함.
TestResult를 FireStore에 저장하는 모델(SaveTestResultParams)을 새로 만듦.