### PR TITLE
테스트 결과가 저장되지 않아 앱을 껐다 켜도 이전 결과가 보이지 않던 이슈 해결

### DIFF
--- a/app/src/main/java/com/udtt/applegamsung/data/remote/params/SaveTestResultParams.kt
+++ b/app/src/main/java/com/udtt/applegamsung/data/remote/params/SaveTestResultParams.kt
@@ -7,7 +7,7 @@ data class SaveTestResultParams(
     val deviceId: String,
     val nickname: String,
     val totalScore: Int,
-    @ServerTimestamp
     val productList: List<String>,
+    @ServerTimestamp
     val timeStamp: Date,
 )


### PR DESCRIPTION
`@ServerTimestamp` 의 위치가 timestamp가 아닌 productList에 잘못 들어가있었음.
이것 때문에 TestResultRepository 에서 remoteSource에 데이터를 저장할 때 에러가 발생했고,
onFailure를 타고 함수가 종료되어 local에는 저장되지 않던 이슈가 생김.
