### PR TITLE
테스트 결과 페이지에서 유저가 갖고 있는 제품 태그를 데이터로 분리

### DIFF
--- a/app/src/main/java/com/udtt/applegamsung/config/di/AppModule.kt
+++ b/app/src/main/java/com/udtt/applegamsung/config/di/AppModule.kt
@@ -25,5 +25,5 @@ val diModules = listOf(
     localDataSourceModule,
     firestoreModule,
     remoteDataSourceModule,
-    repositoryModule
+    repositoryModule,
 )

--- a/app/src/main/java/com/udtt/applegamsung/config/di/DatabaseModule.kt
+++ b/app/src/main/java/com/udtt/applegamsung/config/di/DatabaseModule.kt
@@ -8,18 +8,22 @@ import com.udtt.applegamsung.data.database.migration.AppleProductEntityMigration
 import com.udtt.applegamsung.data.repository.DefaultAppleBoxItemsRepository
 import com.udtt.applegamsung.data.repository.DefaultCategoriesRepository
 import com.udtt.applegamsung.data.repository.DefaultProductsRepository
+import com.udtt.applegamsung.data.repository.DefaultTestResultProductsRepository
 import com.udtt.applegamsung.data.repository.DefaultTestResultsRepository
 import com.udtt.applegamsung.data.repository.UserIdentifyRepository
 import com.udtt.applegamsung.data.source.local.LocalAppleBoxItemsDataSource
 import com.udtt.applegamsung.data.source.local.LocalCategoriesDataSource
 import com.udtt.applegamsung.data.source.local.LocalProductsDataSource
+import com.udtt.applegamsung.data.source.local.LocalTestResultProductsDataSource
 import com.udtt.applegamsung.data.source.local.LocalTestResultsDataSource
 import com.udtt.applegamsung.data.source.remote.RemoteCategoriesDataSource
 import com.udtt.applegamsung.data.source.remote.RemoteProductsDataSource
+import com.udtt.applegamsung.data.source.remote.RemoteTestResultProductsDataSource
 import com.udtt.applegamsung.data.source.remote.RemoteTestResultsDataSource
 import com.udtt.applegamsung.domain.repository.AppleBoxItemsRepository
 import com.udtt.applegamsung.domain.repository.CategoriesRepository
 import com.udtt.applegamsung.domain.repository.ProductsRepository
+import com.udtt.applegamsung.domain.repository.TestResultProductsRepository
 import com.udtt.applegamsung.domain.repository.TestResultsRepository
 import org.koin.android.ext.koin.androidContext
 import org.koin.dsl.module
@@ -59,6 +63,11 @@ val localDataSourceModule = module {
             get<AppDatabase>().getAppleProductsDao(),
         )
     }
+    single {
+        LocalTestResultProductsDataSource(
+            get<AppDatabase>().getTestResultProductsDao(),
+        )
+    }
 }
 
 val firestoreModule = module {
@@ -69,6 +78,7 @@ val remoteDataSourceModule = module {
     single { RemoteCategoriesDataSource(get()) }
     single { RemoteProductsDataSource(get()) }
     single { RemoteTestResultsDataSource(get()) }
+    single { RemoteTestResultProductsDataSource(get()) }
 }
 
 val repositoryModule = module {
@@ -95,6 +105,12 @@ val repositoryModule = module {
     single<AppleBoxItemsRepository> {
         DefaultAppleBoxItemsRepository(
             get<LocalAppleBoxItemsDataSource>()
+        )
+    }
+    single<TestResultProductsRepository> {
+        DefaultTestResultProductsRepository(
+            get<LocalTestResultProductsDataSource>(),
+            get<RemoteTestResultProductsDataSource>(),
         )
     }
 }

--- a/app/src/main/java/com/udtt/applegamsung/data/dao/TestResultProductsDao.kt
+++ b/app/src/main/java/com/udtt/applegamsung/data/dao/TestResultProductsDao.kt
@@ -1,0 +1,16 @@
+package com.udtt.applegamsung.data.dao
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.Query
+import com.udtt.applegamsung.data.entity.TestResultProductEntity
+
+@Dao
+interface TestResultProductsDao {
+
+    @Insert
+    suspend fun insertTestResultProducts(products: List<TestResultProductEntity>)
+
+    @Query("SELECT * FROM TestResultProductEntity")
+    suspend fun getAllTestResultProducts(): List<TestResultProductEntity>
+}

--- a/app/src/main/java/com/udtt/applegamsung/data/database/AppDatabase.kt
+++ b/app/src/main/java/com/udtt/applegamsung/data/database/AppDatabase.kt
@@ -7,6 +7,7 @@ import androidx.room.TypeConverters
 import com.udtt.applegamsung.data.dao.ApplePowersDao
 import com.udtt.applegamsung.data.dao.AppleProductCategoriesDao
 import com.udtt.applegamsung.data.dao.AppleProductsDao
+import com.udtt.applegamsung.data.dao.TestResultProductsDao
 import com.udtt.applegamsung.data.dao.TestResultsDao
 import com.udtt.applegamsung.data.database.migration.RecreateEntitiesMigration
 import com.udtt.applegamsung.data.entity.*
@@ -19,11 +20,12 @@ import com.udtt.applegamsung.data.util.DateTypeConverter
         AppleProductEntity::class,
         AppleProductCategoryEntity::class,
         TestResultEntity::class,
+        TestResultProductEntity::class,
     ],
     autoMigrations = [
         AutoMigration(from = 1, to = 2, spec = RecreateEntitiesMigration::class)
     ],
-    version = 4,
+    version = 5,
 )
 
 abstract class AppDatabase : RoomDatabase() {
@@ -35,4 +37,6 @@ abstract class AppDatabase : RoomDatabase() {
     abstract fun getAppleProductCategoriesDao(): AppleProductCategoriesDao
 
     abstract fun getTestResultsDao(): TestResultsDao
+
+    abstract fun getTestResultProductsDao(): TestResultProductsDao
 }

--- a/app/src/main/java/com/udtt/applegamsung/data/entity/TestResultProductEntity.kt
+++ b/app/src/main/java/com/udtt/applegamsung/data/entity/TestResultProductEntity.kt
@@ -1,0 +1,14 @@
+package com.udtt.applegamsung.data.entity
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+@Entity
+data class TestResultProductEntity(
+    @PrimaryKey
+    val id: String,
+    val name: String,
+    val categoryId: String,
+    val productId: String?,
+    val orderIndex: Int,
+)

--- a/app/src/main/java/com/udtt/applegamsung/data/local/mapper/TestResultProductEntityMapper.kt
+++ b/app/src/main/java/com/udtt/applegamsung/data/local/mapper/TestResultProductEntityMapper.kt
@@ -1,0 +1,24 @@
+package com.udtt.applegamsung.data.local.mapper
+
+import com.udtt.applegamsung.data.entity.TestResultProductEntity
+import com.udtt.applegamsung.domain.model.testresult.TestResultProduct
+
+fun TestResultProductEntity.toTestResultProduct(): TestResultProduct {
+    return TestResultProduct(
+        id = id,
+        name = name,
+        categoryId = categoryId,
+        productId = productId,
+        orderIndex = orderIndex,
+    )
+}
+
+fun TestResultProduct.toTestResultProductEntity(): TestResultProductEntity {
+    return TestResultProductEntity(
+        id = id,
+        name = name,
+        categoryId = categoryId,
+        productId = productId,
+        orderIndex = orderIndex,
+    )
+}

--- a/app/src/main/java/com/udtt/applegamsung/data/repository/DefaultTestResultProductsRepository.kt
+++ b/app/src/main/java/com/udtt/applegamsung/data/repository/DefaultTestResultProductsRepository.kt
@@ -1,0 +1,25 @@
+package com.udtt.applegamsung.data.repository
+
+import com.udtt.applegamsung.data.source.TestResultProductsDataSource
+import com.udtt.applegamsung.domain.model.testresult.TestResultProduct
+import com.udtt.applegamsung.domain.repository.TestResultProductsRepository
+import com.udtt.applegamsung.util.getOrEmpty
+
+class DefaultTestResultProductsRepository(
+    private val localTestResultProductsDataSource: TestResultProductsDataSource,
+    private val remoteTestResultProductsDataSource: TestResultProductsDataSource,
+) : TestResultProductsRepository {
+
+    override suspend fun getAllTestResultProducts(): Result<List<TestResultProduct>> {
+        val localTestResultProducts = localTestResultProductsDataSource.getAllTestResultProducts()
+        if (localTestResultProducts.getOrEmpty().isNotEmpty()) {
+            return localTestResultProducts
+        }
+        return remoteTestResultProductsDataSource.getAllTestResultProducts()
+            .onSuccess { localTestResultProductsDataSource.saveTestResultProduct(it) }
+    }
+
+    override suspend fun saveTestResultProduct(testResultProducts: List<TestResultProduct>): Result<Unit> {
+        return localTestResultProductsDataSource.saveTestResultProduct(testResultProducts)
+    }
+}

--- a/app/src/main/java/com/udtt/applegamsung/data/source/TestResultProductsDataSource.kt
+++ b/app/src/main/java/com/udtt/applegamsung/data/source/TestResultProductsDataSource.kt
@@ -1,0 +1,10 @@
+package com.udtt.applegamsung.data.source
+
+import com.udtt.applegamsung.domain.model.testresult.TestResultProduct
+
+interface TestResultProductsDataSource {
+
+    suspend fun getAllTestResultProducts(): Result<List<TestResultProduct>>
+
+    suspend fun saveTestResultProduct(testResultProducts: List<TestResultProduct>): Result<Unit>
+}

--- a/app/src/main/java/com/udtt/applegamsung/data/source/local/LocalTestResultProductsDataSource.kt
+++ b/app/src/main/java/com/udtt/applegamsung/data/source/local/LocalTestResultProductsDataSource.kt
@@ -1,0 +1,24 @@
+package com.udtt.applegamsung.data.source.local
+
+import com.udtt.applegamsung.data.dao.TestResultProductsDao
+import com.udtt.applegamsung.data.local.mapper.toTestResultProduct
+import com.udtt.applegamsung.data.local.mapper.toTestResultProductEntity
+import com.udtt.applegamsung.data.source.TestResultProductsDataSource
+import com.udtt.applegamsung.domain.model.testresult.TestResultProduct
+
+class LocalTestResultProductsDataSource(
+    private val testResultProductsDao: TestResultProductsDao,
+) : TestResultProductsDataSource {
+
+    override suspend fun getAllTestResultProducts(): Result<List<TestResultProduct>> {
+        return runCatching { testResultProductsDao.getAllTestResultProducts() }
+            .map { testResultProducts -> testResultProducts.map { it.toTestResultProduct() } }
+    }
+
+    override suspend fun saveTestResultProduct(testResultProducts: List<TestResultProduct>): Result<Unit> {
+        return runCatching {
+            testResultProductsDao.insertTestResultProducts(
+                testResultProducts.map { it.toTestResultProductEntity() })
+        }
+    }
+}

--- a/app/src/main/java/com/udtt/applegamsung/data/source/remote/RemoteTestResultProductsDataSource.kt
+++ b/app/src/main/java/com/udtt/applegamsung/data/source/remote/RemoteTestResultProductsDataSource.kt
@@ -1,0 +1,37 @@
+package com.udtt.applegamsung.data.source.remote
+
+import com.google.firebase.firestore.FirebaseFirestore
+import com.udtt.applegamsung.data.remote.firestore.getDocumentSnapshots
+import com.udtt.applegamsung.data.source.TestResultProductsDataSource
+import com.udtt.applegamsung.domain.model.testresult.TestResultProduct
+
+class RemoteTestResultProductsDataSource(
+    private val firestore: FirebaseFirestore,
+) : TestResultProductsDataSource {
+
+    override suspend fun getAllTestResultProducts(): Result<List<TestResultProduct>> {
+        return firestore.collection(PathTestResultProduct)
+            .getDocumentSnapshots()
+            .map { documents ->
+                documents.map {
+                    TestResultProduct(
+                        id = it.id,
+                        name = it.getString("name").orEmpty(),
+                        categoryId = it.getString("categoryId").orEmpty(),
+                        productId = it.getString("productId").orEmpty(),
+                        orderIndex = it.getLong("name")?.toInt() ?: 0,
+                    )
+                }
+            }
+    }
+
+    override suspend fun saveTestResultProduct(testResultProducts: List<TestResultProduct>): Result<Unit> {
+        return Result.failure(
+            UnsupportedOperationException("Do not call saveTestResultProduct() in remoteSource")
+        )
+    }
+
+    companion object {
+        private const val PathTestResultProduct = "TestResultProduct"
+    }
+}

--- a/app/src/main/java/com/udtt/applegamsung/domain/model/testresult/TestResultProduct.kt
+++ b/app/src/main/java/com/udtt/applegamsung/domain/model/testresult/TestResultProduct.kt
@@ -1,0 +1,12 @@
+package com.udtt.applegamsung.domain.model.testresult
+
+data class TestResultProduct(
+    val id: String,
+    val name: String,
+    val categoryId: String,
+    val productId: String?,
+    val orderIndex: Int,
+) {
+    val isCategory: Boolean = productId == null
+    val isProduct: Boolean = productId != null
+}

--- a/app/src/main/java/com/udtt/applegamsung/domain/repository/TestResultProductsRepository.kt
+++ b/app/src/main/java/com/udtt/applegamsung/domain/repository/TestResultProductsRepository.kt
@@ -1,0 +1,10 @@
+package com.udtt.applegamsung.domain.repository
+
+import com.udtt.applegamsung.domain.model.testresult.TestResultProduct
+
+interface TestResultProductsRepository {
+
+    suspend fun getAllTestResultProducts(): Result<List<TestResultProduct>>
+
+    suspend fun saveTestResultProduct(testResultProducts: List<TestResultProduct>): Result<Unit>
+}


### PR DESCRIPTION
![image](https://github.com/malibinYun/UDTT-AppleGamsung/assets/44341119/6211170c-895c-4a1e-bf81-c329912b5a8b)

위 화면에서 나타나는 제품 태그는 단순히 Presentation Layer에서 저장된 제품 데이터의 이름을 비교함으로써 구현했었음.
아래 이유들로, 이 데이터를 서버에 저장된 데이터로 분리하고자 함.

1. 조금 더 유연한 데이터를 보여주고자 함.
    - 클라이언트에 박혀있다면, 앱을 업데이트 하지 않으면 변경할 수 없게됨.
    - 서버의 데이터를 바꿈으로써 유연함과 확장성을 부여하고자 함.

2. 보여주는 태그에 단순히 Product 혹은 Category가 아닌 것들이 존재함.
    - 맥만 Product 정보들을 보여주고 있으며, 나머지는 Category만을 보여주고 있음.
    - Category를 보여주는 것에서도 `가진 것 없음`은 없어야하며, `ipods`는 이름이 달라 곤란했음.
    - Product + Category 로 UseCase 등을 활용해서 조합해보려했지만 굉장히 까다로워졌음.
    - 이 보유 제품 태그를 입맛대로 수정하고 싶게 된다면, 위 Product + Category를 코드로 조합한 것은 의미가 없어진다고 생각함. 또 똑같은 코드를 작성해야하며, 굉장히 번거로울 것이라고 판단함.
    

----

TestResultProduct 모델을 만들었음.

- `name` - 태그에 보여줄 이름
- `cagegoryId` - 태그에 해당하는 카테고리 id를 가지고 있음.
- `productId` - 태그에 해당하는 제품 id를 가지고 있음.
    - 태그는 하나의 카테고리만을 나타내기도 하므로, 특정한 제품이 없으면 해당 Id는 null임.
- `orderIndex` - 태그가 보여질 정렬 순서를 나타냄.

----

Firestore에는 저장 완료했음.

- #29 

이 Issue 해결을 위해서 진행됨
