### PR TITLE
Result의 값이 List일 때 다른 List로 매핑할 수 있는 확장함수 추가 및 마이그레이션

### DIFF
--- a/app/src/main/java/com/udtt/applegamsung/data/repository/DefaultProductsRepository.kt
+++ b/app/src/main/java/com/udtt/applegamsung/data/repository/DefaultProductsRepository.kt
@@ -1,11 +1,12 @@
 package com.udtt.applegamsung.data.repository
 
 import com.udtt.applegamsung.data.entity.DisplayedProduct
-import com.udtt.applegamsung.domain.model.product.Product
 import com.udtt.applegamsung.data.source.AppleBoxItemsDataSource
 import com.udtt.applegamsung.data.source.ProductsDataSource
+import com.udtt.applegamsung.domain.model.product.Product
 import com.udtt.applegamsung.domain.repository.ProductsRepository
 import com.udtt.applegamsung.util.getOrEmpty
+import com.udtt.applegamsung.util.mapList
 
 class DefaultProductsRepository(
     private val remoteProductsDataSource: ProductsDataSource,
@@ -28,7 +29,7 @@ class DefaultProductsRepository(
 
     override suspend fun getDisplayedProducts(categoryId: String): Result<List<DisplayedProduct>> {
         val displayedProducts = getProducts(categoryId)
-            .map { it.map { product -> DisplayedProduct(product) } }
+            .mapList { product -> DisplayedProduct(product) }
             .onFailure { return Result.failure(it) }
             .getOrEmpty()
 

--- a/app/src/main/java/com/udtt/applegamsung/data/source/local/LocalAppleBoxItemsDataSource.kt
+++ b/app/src/main/java/com/udtt/applegamsung/data/source/local/LocalAppleBoxItemsDataSource.kt
@@ -5,6 +5,7 @@ import com.udtt.applegamsung.data.entity.AppleBoxItem
 import com.udtt.applegamsung.data.local.mapper.toAppleBoxItem
 import com.udtt.applegamsung.data.local.mapper.toAppleProductEntity
 import com.udtt.applegamsung.data.source.AppleBoxItemsDataSource
+import com.udtt.applegamsung.util.mapList
 
 class LocalAppleBoxItemsDataSource(
     private val appleProductsDao: AppleProductsDao,
@@ -12,9 +13,7 @@ class LocalAppleBoxItemsDataSource(
 
     override suspend fun getAppleBoxItems(): Result<List<AppleBoxItem>> {
         return runCatching { appleProductsDao.getInBoxAppleProducts() }
-            .map { appleProductEntities ->
-                appleProductEntities.map { it.toAppleBoxItem() }
-            }
+            .mapList { it.toAppleBoxItem() }
     }
 
     override suspend fun saveAppleBoxItems(appleBoxItems: List<AppleBoxItem>): Result<Unit> {

--- a/app/src/main/java/com/udtt/applegamsung/data/source/local/LocalCategoriesDataSource.kt
+++ b/app/src/main/java/com/udtt/applegamsung/data/source/local/LocalCategoriesDataSource.kt
@@ -1,10 +1,11 @@
 package com.udtt.applegamsung.data.source.local
 
 import com.udtt.applegamsung.data.dao.AppleProductCategoriesDao
-import com.udtt.applegamsung.domain.model.category.Category
 import com.udtt.applegamsung.data.local.mapper.toAppleProductCategoryEntity
 import com.udtt.applegamsung.data.local.mapper.toCategory
 import com.udtt.applegamsung.data.source.CategoriesDataSource
+import com.udtt.applegamsung.domain.model.category.Category
+import com.udtt.applegamsung.util.mapList
 
 /**
  * Created By Yun Hyeok
@@ -17,7 +18,7 @@ class LocalCategoriesDataSource(
 
     override suspend fun getCategories(): Result<List<Category>> {
         return runCatching { appleProductCategoriesDao.getCategories() }
-            .map { categoryEntities -> categoryEntities.map { it.toCategory() } }
+            .mapList { it.toCategory() }
     }
 
     override suspend fun saveCategories(categories: List<Category>): Result<Unit> {

--- a/app/src/main/java/com/udtt/applegamsung/data/source/local/LocalProductsDataSource.kt
+++ b/app/src/main/java/com/udtt/applegamsung/data/source/local/LocalProductsDataSource.kt
@@ -1,10 +1,11 @@
 package com.udtt.applegamsung.data.source.local
 
 import com.udtt.applegamsung.data.dao.AppleProductsDao
-import com.udtt.applegamsung.domain.model.product.Product
 import com.udtt.applegamsung.data.local.mapper.toAppleProductEntity
 import com.udtt.applegamsung.data.local.mapper.toProduct
 import com.udtt.applegamsung.data.source.ProductsDataSource
+import com.udtt.applegamsung.domain.model.product.Product
+import com.udtt.applegamsung.util.mapList
 
 /**
  * Created By Yun Hyeok
@@ -17,7 +18,7 @@ class LocalProductsDataSource(
 
     override suspend fun getProducts(categoryId: String): Result<List<Product>> {
         return runCatching { appleProductsDao.getProductsByCategoryId(categoryId) }
-            .map { productEntities -> productEntities.map { it.toProduct() } }
+            .mapList { it.toProduct() }
     }
 
     override suspend fun saveProducts(products: List<Product>): Result<Unit> {

--- a/app/src/main/java/com/udtt/applegamsung/data/source/local/LocalTestResultProductsDataSource.kt
+++ b/app/src/main/java/com/udtt/applegamsung/data/source/local/LocalTestResultProductsDataSource.kt
@@ -5,6 +5,7 @@ import com.udtt.applegamsung.data.local.mapper.toTestResultProduct
 import com.udtt.applegamsung.data.local.mapper.toTestResultProductEntity
 import com.udtt.applegamsung.data.source.TestResultProductsDataSource
 import com.udtt.applegamsung.domain.model.testresult.TestResultProduct
+import com.udtt.applegamsung.util.mapList
 
 class LocalTestResultProductsDataSource(
     private val testResultProductsDao: TestResultProductsDao,
@@ -12,7 +13,7 @@ class LocalTestResultProductsDataSource(
 
     override suspend fun getAllTestResultProducts(): Result<List<TestResultProduct>> {
         return runCatching { testResultProductsDao.getAllTestResultProducts() }
-            .map { testResultProducts -> testResultProducts.map { it.toTestResultProduct() } }
+            .mapList { it.toTestResultProduct() }
     }
 
     override suspend fun saveTestResultProduct(testResultProducts: List<TestResultProduct>): Result<Unit> {

--- a/app/src/main/java/com/udtt/applegamsung/data/source/local/LocalTestResultsDataSource.kt
+++ b/app/src/main/java/com/udtt/applegamsung/data/source/local/LocalTestResultsDataSource.kt
@@ -2,13 +2,14 @@ package com.udtt.applegamsung.data.source.local
 
 import com.udtt.applegamsung.data.dao.ApplePowersDao
 import com.udtt.applegamsung.data.dao.TestResultsDao
-import com.udtt.applegamsung.domain.model.testresult.applepower.ApplePower
-import com.udtt.applegamsung.domain.model.testresult.TestResult
 import com.udtt.applegamsung.data.local.mapper.toApplePower
 import com.udtt.applegamsung.data.local.mapper.toApplePowerEntity
 import com.udtt.applegamsung.data.local.mapper.toTestResult
 import com.udtt.applegamsung.data.local.mapper.toTestResultEntity
 import com.udtt.applegamsung.data.source.TestResultsDataSource
+import com.udtt.applegamsung.domain.model.testresult.TestResult
+import com.udtt.applegamsung.domain.model.testresult.applepower.ApplePower
+import com.udtt.applegamsung.util.mapList
 
 /**
  * Created By Yun Hyeok
@@ -22,7 +23,7 @@ class LocalTestResultsDataSource(
 
     override suspend fun getTestResults(): Result<List<TestResult>> {
         return runCatching { testResultsDao.getTestResults() }
-            .map { testResultEntities -> testResultEntities.map { it.toTestResult() } }
+            .mapList { it.toTestResult() }
     }
 
     override suspend fun saveTestResult(testResult: TestResult): Result<Unit> {
@@ -33,7 +34,7 @@ class LocalTestResultsDataSource(
 
     override suspend fun getApplePowers(): Result<List<ApplePower>> {
         return runCatching { applePowersDao.getApplePowers() }
-            .map { applePowerEntities -> applePowerEntities.map { it.toApplePower() } }
+            .mapList { it.toApplePower() }
     }
 
     override suspend fun getApplePower(totalScore: Int): Result<ApplePower?> {

--- a/app/src/main/java/com/udtt/applegamsung/data/source/remote/RemoteCategoriesDataSource.kt
+++ b/app/src/main/java/com/udtt/applegamsung/data/source/remote/RemoteCategoriesDataSource.kt
@@ -4,6 +4,7 @@ import com.google.firebase.firestore.FirebaseFirestore
 import com.udtt.applegamsung.data.remote.firestore.getDocumentSnapshots
 import com.udtt.applegamsung.data.source.CategoriesDataSource
 import com.udtt.applegamsung.domain.model.category.Category
+import com.udtt.applegamsung.util.mapList
 
 /**
  * Created By Yun Hyeok
@@ -17,15 +18,13 @@ class RemoteCategoriesDataSource(
     override suspend fun getCategories(): Result<List<Category>> {
         return firestore.collection(PathCategory)
             .getDocumentSnapshots()
-            .map { documents ->
-                documents.map {
-                    Category(
-                        id = it.id,
-                        name = it.getString("name").orEmpty(),
-                        index = it.getLong("index")?.toInt() ?: 0,
-                        imageUrl = it.getString("imageUrl").orEmpty(),
-                    )
-                }
+            .mapList {
+                Category(
+                    id = it.id,
+                    name = it.getString("name").orEmpty(),
+                    index = it.getLong("index")?.toInt() ?: 0,
+                    imageUrl = it.getString("imageUrl").orEmpty(),
+                )
             }
     }
 

--- a/app/src/main/java/com/udtt/applegamsung/data/source/remote/RemoteProductsDataSource.kt
+++ b/app/src/main/java/com/udtt/applegamsung/data/source/remote/RemoteProductsDataSource.kt
@@ -4,6 +4,7 @@ import com.google.firebase.firestore.FirebaseFirestore
 import com.udtt.applegamsung.data.remote.firestore.getDocumentSnapshots
 import com.udtt.applegamsung.data.source.ProductsDataSource
 import com.udtt.applegamsung.domain.model.product.Product
+import com.udtt.applegamsung.util.mapList
 
 /**
  * Created By Yun Hyeok
@@ -19,17 +20,15 @@ class RemoteProductsDataSource(
             .document(categoryId)
             .collection(PathProducts)
             .getDocumentSnapshots()
-            .map { documents ->
-                documents.map {
-                    Product(
-                        id = it.id,
-                        name = it.getString("name").orEmpty(),
-                        score = it.getLong("score")?.toInt() ?: 0,
-                        categoryIndex = it.getLong("categoryIndex")?.toInt() ?: 0,
-                        categoryId = it.getString("categoryId").orEmpty(),
-                        imageUrl = ""
-                    )
-                }
+            .mapList {
+                Product(
+                    id = it.id,
+                    name = it.getString("name").orEmpty(),
+                    score = it.getLong("score")?.toInt() ?: 0,
+                    categoryIndex = it.getLong("categoryIndex")?.toInt() ?: 0,
+                    categoryId = it.getString("categoryId").orEmpty(),
+                    imageUrl = ""
+                )
             }
     }
 

--- a/app/src/main/java/com/udtt/applegamsung/data/source/remote/RemoteTestResultProductsDataSource.kt
+++ b/app/src/main/java/com/udtt/applegamsung/data/source/remote/RemoteTestResultProductsDataSource.kt
@@ -4,6 +4,7 @@ import com.google.firebase.firestore.FirebaseFirestore
 import com.udtt.applegamsung.data.remote.firestore.getDocumentSnapshots
 import com.udtt.applegamsung.data.source.TestResultProductsDataSource
 import com.udtt.applegamsung.domain.model.testresult.TestResultProduct
+import com.udtt.applegamsung.util.mapList
 
 class RemoteTestResultProductsDataSource(
     private val firestore: FirebaseFirestore,
@@ -12,16 +13,14 @@ class RemoteTestResultProductsDataSource(
     override suspend fun getAllTestResultProducts(): Result<List<TestResultProduct>> {
         return firestore.collection(PathTestResultProduct)
             .getDocumentSnapshots()
-            .map { documents ->
-                documents.map {
-                    TestResultProduct(
-                        id = it.id,
-                        name = it.getString("name").orEmpty(),
-                        categoryId = it.getString("categoryId").orEmpty(),
-                        productId = it.getString("productId").orEmpty(),
-                        orderIndex = it.getLong("name")?.toInt() ?: 0,
-                    )
-                }
+            .mapList {
+                TestResultProduct(
+                    id = it.id,
+                    name = it.getString("name").orEmpty(),
+                    categoryId = it.getString("categoryId").orEmpty(),
+                    productId = it.getString("productId").orEmpty(),
+                    orderIndex = it.getLong("name")?.toInt() ?: 0,
+                )
             }
     }
 

--- a/app/src/main/java/com/udtt/applegamsung/data/source/remote/RemoteTestResultsDataSource.kt
+++ b/app/src/main/java/com/udtt/applegamsung/data/source/remote/RemoteTestResultsDataSource.kt
@@ -7,6 +7,7 @@ import com.udtt.applegamsung.data.remote.mapper.toSaveResultParams
 import com.udtt.applegamsung.data.source.TestResultsDataSource
 import com.udtt.applegamsung.domain.model.testresult.TestResult
 import com.udtt.applegamsung.domain.model.testresult.applepower.ApplePower
+import com.udtt.applegamsung.util.mapList
 
 /**
  * Created By Yun Hyeok
@@ -31,17 +32,15 @@ class RemoteTestResultsDataSource(
     override suspend fun getApplePowers(): Result<List<ApplePower>> {
         return firestore.collection(PathApplePower)
             .getDocumentSnapshots()
-            .map { documents ->
-                documents.map {
-                    ApplePower(
-                        id = it.id,
-                        name = it.getString("name").orEmpty(),
-                        description = it.getString("description").orEmpty(),
-                        minPower = it.getLong("minPower")?.toInt() ?: 0,
-                        maxPower = it.getLong("maxPower")?.toInt() ?: 0,
-                        imageUrl = it.getString("imageUrl").orEmpty(),
-                    )
-                }
+            .mapList {
+                ApplePower(
+                    id = it.id,
+                    name = it.getString("name").orEmpty(),
+                    description = it.getString("description").orEmpty(),
+                    minPower = it.getLong("minPower")?.toInt() ?: 0,
+                    maxPower = it.getLong("maxPower")?.toInt() ?: 0,
+                    imageUrl = it.getString("imageUrl").orEmpty(),
+                )
             }
     }
 

--- a/app/src/main/java/com/udtt/applegamsung/util/ResultExtensions.kt
+++ b/app/src/main/java/com/udtt/applegamsung/util/ResultExtensions.kt
@@ -3,3 +3,7 @@ package com.udtt.applegamsung.util
 fun <T> Result<List<T>>.getOrEmpty(): List<T> {
     return this.getOrNull().orEmpty()
 }
+
+inline fun <T, R> Result<List<T>>.mapList(transform: (T) -> R): Result<List<R>> {
+    return this.map { it.map(transform) }
+}


### PR DESCRIPTION
Result에서 List 타입을 가지는 경우, 해당 List\<T>를 List\<R>로 매핑해야할 때 map이 2번 중첩되어 매우 불편했음.
map 이중 중첩과 편리한 사용을 위해서, Result\<List\<T>> 에서 바로 Result\<List\<R>>로 매핑할 수 있는 확장함수를 추가함.

### AS-IS

```kotlin
val foosResult: Result<List<Foo>>

val barsResult: Result<List<Bar>> = foosResult.map { foos ->
    foos.map { foo -> foo.toBar() }
}
```

### TO-BE

```kotlin
val foosResult: Result<List<Foo>>

val barsResult: Result<List<Bar>> = foosResult.mapList { foo -> foo.toBar() }
```

