### PR TITLE
Products 도메인 모델 추가 및 마이그레이션

### DIFF
--- a/app/src/main/java/com/udtt/applegamsung/data/repository/DefaultProductsRepository.kt
+++ b/app/src/main/java/com/udtt/applegamsung/data/repository/DefaultProductsRepository.kt
@@ -4,6 +4,7 @@ import com.udtt.applegamsung.data.entity.DisplayedProduct
 import com.udtt.applegamsung.data.source.AppleBoxItemsDataSource
 import com.udtt.applegamsung.data.source.ProductsDataSource
 import com.udtt.applegamsung.domain.model.product.Product
+import com.udtt.applegamsung.domain.model.product.Products
 import com.udtt.applegamsung.domain.repository.ProductsRepository
 import com.udtt.applegamsung.util.getOrEmpty
 import com.udtt.applegamsung.util.mapList
@@ -14,13 +15,13 @@ class DefaultProductsRepository(
     private val localAppleBoxItemsDataSource: AppleBoxItemsDataSource,
 ) : ProductsRepository {
 
-    override suspend fun getProducts(categoryId: String): Result<List<Product>> {
-        val localProducts = localProductsDataSource.getProducts(categoryId)
-        if (localProducts.getOrEmpty().isNotEmpty()) {
-            return localProducts
-        }
+    override suspend fun getProducts(categoryId: String): Result<Products> {
+        localProductsDataSource.getProducts(categoryId)
+            .onSuccess { if (it.isNotEmpty()) return Result.success(it) }
+            .onFailure { return Result.failure(it) }
+
         return remoteProductsDataSource.getProducts(categoryId)
-            .onSuccess { saveProducts(it) }
+            .onSuccess { saveProducts(it.getValues()) }
     }
 
     override suspend fun saveProducts(products: List<Product>): Result<Unit> {
@@ -29,6 +30,7 @@ class DefaultProductsRepository(
 
     override suspend fun getDisplayedProducts(categoryId: String): Result<List<DisplayedProduct>> {
         val displayedProducts = getProducts(categoryId)
+            .map { it.getValues() }
             .mapList { product -> DisplayedProduct(product) }
             .onFailure { return Result.failure(it) }
             .getOrEmpty()

--- a/app/src/main/java/com/udtt/applegamsung/data/source/ProductsDataSource.kt
+++ b/app/src/main/java/com/udtt/applegamsung/data/source/ProductsDataSource.kt
@@ -1,6 +1,7 @@
 package com.udtt.applegamsung.data.source
 
 import com.udtt.applegamsung.domain.model.product.Product
+import com.udtt.applegamsung.domain.model.product.Products
 
 /**
  * Created By Yun Hyeok
@@ -9,7 +10,7 @@ import com.udtt.applegamsung.domain.model.product.Product
 
 interface ProductsDataSource {
 
-    suspend fun getProducts(categoryId: String): Result<List<Product>>
+    suspend fun getProducts(categoryId: String): Result<Products>
 
     suspend fun saveProducts(products: List<Product>): Result<Unit>
 }

--- a/app/src/main/java/com/udtt/applegamsung/data/source/local/LocalProductsDataSource.kt
+++ b/app/src/main/java/com/udtt/applegamsung/data/source/local/LocalProductsDataSource.kt
@@ -5,6 +5,7 @@ import com.udtt.applegamsung.data.local.mapper.toAppleProductEntity
 import com.udtt.applegamsung.data.local.mapper.toProduct
 import com.udtt.applegamsung.data.source.ProductsDataSource
 import com.udtt.applegamsung.domain.model.product.Product
+import com.udtt.applegamsung.domain.model.product.Products
 import com.udtt.applegamsung.util.mapList
 
 /**
@@ -16,15 +17,16 @@ class LocalProductsDataSource(
     private val appleProductsDao: AppleProductsDao,
 ) : ProductsDataSource {
 
-    override suspend fun getProducts(categoryId: String): Result<List<Product>> {
+    override suspend fun getProducts(categoryId: String): Result<Products> {
         return runCatching { appleProductsDao.getProductsByCategoryId(categoryId) }
             .mapList { it.toProduct() }
+            .map { Products(it) }
     }
 
     override suspend fun saveProducts(products: List<Product>): Result<Unit> {
         return runCatching {
             appleProductsDao.insertProducts(
-                products.map { it.toAppleProductEntity() }
+                products.map { it.toAppleProductEntity() },
             )
         }
     }

--- a/app/src/main/java/com/udtt/applegamsung/data/source/remote/RemoteProductsDataSource.kt
+++ b/app/src/main/java/com/udtt/applegamsung/data/source/remote/RemoteProductsDataSource.kt
@@ -4,6 +4,7 @@ import com.google.firebase.firestore.FirebaseFirestore
 import com.udtt.applegamsung.data.remote.firestore.getDocumentSnapshots
 import com.udtt.applegamsung.data.source.ProductsDataSource
 import com.udtt.applegamsung.domain.model.product.Product
+import com.udtt.applegamsung.domain.model.product.Products
 import com.udtt.applegamsung.util.mapList
 
 /**
@@ -12,10 +13,10 @@ import com.udtt.applegamsung.util.mapList
  */
 
 class RemoteProductsDataSource(
-    private val firestore: FirebaseFirestore
+    private val firestore: FirebaseFirestore,
 ) : ProductsDataSource {
 
-    override suspend fun getProducts(categoryId: String): Result<List<Product>> {
+    override suspend fun getProducts(categoryId: String): Result<Products> {
         return firestore.collection(PathCategory)
             .document(categoryId)
             .collection(PathProducts)
@@ -27,14 +28,15 @@ class RemoteProductsDataSource(
                     score = it.getLong("score")?.toInt() ?: 0,
                     categoryIndex = it.getLong("categoryIndex")?.toInt() ?: 0,
                     categoryId = it.getString("categoryId").orEmpty(),
-                    imageUrl = ""
+                    imageUrl = "",
                 )
             }
+            .map { Products(it) }
     }
 
     override suspend fun saveProducts(products: List<Product>): Result<Unit> {
         return Result.failure(
-            UnsupportedOperationException("Do not call saveProducts() in remoteSource")
+            UnsupportedOperationException("Do not call saveProducts() in remoteSource"),
         )
     }
 

--- a/app/src/main/java/com/udtt/applegamsung/domain/model/product/Products.kt
+++ b/app/src/main/java/com/udtt/applegamsung/domain/model/product/Products.kt
@@ -1,0 +1,22 @@
+package com.udtt.applegamsung.domain.model.product
+
+data class Products(
+    private val products: List<Product>,
+) {
+    private val productIds: List<String> by lazy { products.map { it.id } }
+    private val categoryIds: List<String> by lazy { products.map { it.categoryId } }
+
+    fun getValues(): List<Product> = products.toList()
+
+    fun isEmpty(): Boolean = products.isEmpty()
+
+    fun isNotEmpty(): Boolean = products.isNotEmpty()
+
+    fun hasProductOf(productId: String): Boolean = productId in productIds
+
+    fun hasCategoryOf(categoryId: String): Boolean = categoryId in categoryIds
+
+    fun sumScores(): Int = products.sumOf { it.score }
+
+    fun havingCategoriesCount(): Int = categoryIds.size
+}

--- a/app/src/main/java/com/udtt/applegamsung/domain/repository/ProductsRepository.kt
+++ b/app/src/main/java/com/udtt/applegamsung/domain/repository/ProductsRepository.kt
@@ -2,10 +2,11 @@ package com.udtt.applegamsung.domain.repository
 
 import com.udtt.applegamsung.data.entity.DisplayedProduct
 import com.udtt.applegamsung.domain.model.product.Product
+import com.udtt.applegamsung.domain.model.product.Products
 
 interface ProductsRepository {
 
-    suspend fun getProducts(categoryId: String): Result<List<Product>>
+    suspend fun getProducts(categoryId: String): Result<Products>
 
     suspend fun saveProducts(products: List<Product>): Result<Unit>
 


### PR DESCRIPTION
List\<Product\> 사용 보다 Products 일급 컬렉션을 활용해서 로직 응집도를 높혀 보고자 함.

DataSource 및 Repository에서도 List\<Product\> 대신 Products를 반환하게 변경함.